### PR TITLE
CI: Test PR head

### DIFF
--- a/.github/workflows/ci-spectec.yml
+++ b/.github/workflows/ci-spectec.yml
@@ -17,7 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v2
         with:


### PR DESCRIPTION
by default, Github tests a hypothetical merged state, which can lead to PRs being red although they are perfectly fine. That’s annoying.

https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-does-pull_request-affect-actionscheckout