### PR TITLE
IL: A conservative apartness checker

### DIFF
--- a/spectec/src/il/apart.ml
+++ b/spectec/src/il/apart.ml
@@ -1,22 +1,29 @@
+(*
+This module implements a (consservative) apartness check: Given two (open)
+expression (typically reduction rules LHSs), are they definitely apart.
+*)
+
 open Util.Source
 open Ast
 
-(* Turns an expression of list with a know tail into the tail elements (reverse
-   order), and the initial part
+(* Looks at an expression of type list from the back and chops off all
+   known _elements_, followed by the list of all list expressions.
+   Returns it all in reverse order.
  *)
-let rec to_snoc_list (e : exp) : exp list * exp = match e.it with
-  | ListE es -> List.rev es, (ListE [] $ e.at)
+let rec to_snoc_list (e : exp) : exp list * exp list = match e.it with
+  | ListE es -> List.rev es, []
   | CatE (e1, e2) ->
-    let revtail2, init2 = to_snoc_list e2 in
-    if init2.it = ListE []
-    then let revtail1, init = to_snoc_list e1 in
-         revtail2 @ revtail1, init
-    else revtail2, CatE (e1, init2) $ e.at
-  | _ -> [], e
+    let tailelems2, listelems2 = to_snoc_list e2 in
+    if listelems2 = []
+    (* Second list is fully known? Can look at first list *)
+    then let tailelems1, listelems1 = to_snoc_list e1 in
+         tailelems2 @ tailelems1, listelems1
+    (* Second list has unknown elements, have to stop there *)
+    else tailelems2, listelems2 @ [e1]
+  | _ -> [], [e]
 
-(* Are these two open terms definitely apart? *)
-(* We only care about expression of the same type, and do not bother
-   returning true for different types. *)
+(* We assume the expressions to be of the same type; for ill-typed inputs
+   no guarantees are made. *)
 let rec apart (e1 : exp) (e2: exp) : bool =
   if Eq.eq_exp e1 e2 then false else
   (*
@@ -27,7 +34,7 @@ let rec apart (e1 : exp) (e2: exp) : bool =
   | NatE n1, NatE n2 -> not (n1 = n2)
   | BoolE b1, BoolE b2 -> not (b1 = b2)
   | TextE t1, TextE t2 -> not (t1 = t2)
-  | CaseE (a1, exp1, _), CaseE (a2, exp2, _) ->
+  | CaseE (a1, exp1), CaseE (a2, exp2) ->
     not (a1 = a2) || apart exp1 exp2
   | TupE es1, TupE es2 when List.length es1 = List.length es2 ->
     List.exists2 apart es1 es2
@@ -40,10 +47,16 @@ let rec apart (e1 : exp) (e2: exp) : bool =
   | _ , _ -> false (* conservative *)
   )
 
-and list_exp_apart e1 e2 =
-  let revtail1, init1 = to_snoc_list e1 in
-  let revtail2, init2 = to_snoc_list e2 in
-  List.exists2 apart revtail1 revtail2 ||
-  (if List.length revtail1 = List.length revtail2 && revtail1 != []
-  then apart init1 init2
-  else false)
+(* Two list expressions are apart if either their manifest tail elements are apart *)
+and list_exp_apart e1 e2 = snoc_list_apart (to_snoc_list e1) (to_snoc_list e2)
+
+and snoc_list_apart (tailelems1, listelems1) (tailelems2, listelems2) =
+  match tailelems1, listelems1, tailelems2, listelems2 with
+  (* If the heads are apart, the lists are apart *)
+  | e1 :: e1s, _, e2 :: e2s, _ -> apart e1 e2 || snoc_list_apart (e1s, listelems1) (e2s, listelems2)
+  (* If one list is definitely empty and the other list definitely isn't *)
+  | [], [], _ :: _, _ -> false
+  | _ :: _, _, [], [] -> false
+  (* Else, can't tell *)
+  | _, _, _, _ -> false
+

--- a/spectec/src/il/apart.ml
+++ b/spectec/src/il/apart.ml
@@ -1,0 +1,49 @@
+open Util.Source
+open Ast
+
+(* Turns an expression of list with a know tail into the tail elements (reverse
+   order), and the initial part
+ *)
+let rec to_snoc_list (e : exp) : exp list * exp = match e.it with
+  | ListE es -> List.rev es, (ListE [] $ e.at)
+  | CatE (e1, e2) ->
+    let revtail2, init2 = to_snoc_list e2 in
+    if init2.it = ListE []
+    then let revtail1, init = to_snoc_list e1 in
+         revtail2 @ revtail1, init
+    else revtail2, CatE (e1, init2) $ e.at
+  | _ -> [], e
+
+(* Are these two open terms definitely apart? *)
+(* We only care about expression of the same type, and do not bother
+   returning true for different types. *)
+let rec apart (e1 : exp) (e2: exp) : bool =
+  if Eq.eq_exp e1 e2 then false else
+  (*
+  (fun b -> if not b then Printf.eprintf "apart\n  %s\n  %s\n  %b\n" (Print.string_of_exp e1) (Print.string_of_exp e2) b; b)
+  *)
+  (match e1.it, e2.it with
+  (* A literal is never a literal of other type *)
+  | NatE n1, NatE n2 -> not (n1 = n2)
+  | BoolE b1, BoolE b2 -> not (b1 = b2)
+  | TextE t1, TextE t2 -> not (t1 = t2)
+  | CaseE (a1, exp1, _), CaseE (a2, exp2, _) ->
+    not (a1 = a2) || apart exp1 exp2
+  | TupE es1, TupE es2 when List.length es1 = List.length es2 ->
+    List.exists2 apart es1 es2
+  | (CatE _ | ListE _), (CatE _ | ListE _) ->
+    list_exp_apart e1 e2
+  | SubE (e1, _, _), SubE (e2, _, _) -> apart e1 e2
+  | MixE (mixop1, e1), MixE (mixop2, e2) ->
+    not (mixop1 = mixop2) || apart e1 e2
+  (* We do not know anything about variables and functions *)
+  | _ , _ -> false (* conservative *)
+  )
+
+and list_exp_apart e1 e2 =
+  let revtail1, init1 = to_snoc_list e1 in
+  let revtail2, init2 = to_snoc_list e2 in
+  List.exists2 apart revtail1 revtail2 ||
+  (if List.length revtail1 = List.length revtail2 && revtail1 != []
+  then apart init1 init2
+  else false)

--- a/spectec/src/il/apart.mli
+++ b/spectec/src/il/apart.mli
@@ -1,0 +1,2 @@
+open Ast
+val apart : exp -> exp -> bool

--- a/spectec/src/il/dune
+++ b/spectec/src/il/dune
@@ -1,5 +1,5 @@
 (library
   (name il)
   (libraries util)
-  (modules ast eq free print validation)
+  (modules ast eq free print validation apart)
 )


### PR DESCRIPTION
This module adds a check
```
val apart : exp -> exp -> bool
```
with the idea that `apart lhs1 lhs2 = true` means that two reduction rules with these lhs definitely can’t match both.

I extracted it from my (rejected) proposal for how to desugar the `otherwise` construct, but I believe this check will be useful still, as (as far as I understand) Andreas wants to uphold and check the invariant that

> Rules before a rule using `otherwise` must either obviously not match, or have syntactically equal LHSs, and only boolean premises.

The `apart` predicate is the “obviously not match”.

As of today, all rules in the reduction semantics have either `eq` or `apart` LHS, I believe.