### PR TITLE
Minor fixes

### DIFF
--- a/spectec/spec/3-typing.watsup
+++ b/spectec/spec/3-typing.watsup
@@ -139,7 +139,7 @@ rule InstrSeq_ok/seq:
   -- InstrSeq_ok: C |- instr_2 : t_2* -> t_3*
 
 rule InstrSeq_ok/weak:
-  C |- instr* : t'_1 -> t'_2*
+  C |- instr* : t'_1* -> t'_2*
   -- InstrSeq_ok: C |- instr* : t_1* -> t_2*
 
   -- Resulttype_sub: |- t'_1* <: t_1*

--- a/spectec/src/exe-watsup/main.ml
+++ b/spectec/src/exe-watsup/main.ml
@@ -52,7 +52,7 @@ let argspec = Arg.align
   "-p", Arg.Set dst, " Patch files";
   "-d", Arg.Set dry, " Dry run (when -p) ";
   "-l", Arg.Set log, " Log execution steps";
-  "-w", Arg.Set warn, " Warn about unsed or multiply used splices";
+  "-w", Arg.Set warn, " Warn about unused or multiply used splices";
 
   "--check", Arg.Unit (fun () -> target := Check), " Check only";
   "--latex", Arg.Unit (fun () -> target := Latex Backend_latex.Config.latex),
@@ -68,7 +68,7 @@ let argspec = Arg.align
   "--sub", Arg.Set pass_sub, " Synthesize explicit subtype coercions";
   "--totalize", Arg.Set pass_totalize, " Run function totalization";
   "--the-elimination", Arg.Set pass_unthe, " Eliminate the ! operator in relations";
-  "--sideconditions", Arg.Set pass_sideconditions, " Infer side conditoins";
+  "--sideconditions", Arg.Set pass_sideconditions, " Infer side conditions";
 
   "-help", Arg.Unit ignore, "";
   "--help", Arg.Unit ignore, "";

--- a/spectec/src/exe-watsup/main.ml
+++ b/spectec/src/exe-watsup/main.ml
@@ -61,14 +61,14 @@ let argspec = Arg.align
     " Generate Latex for Sphinx";
   "--prose", Arg.Unit (fun () -> target := Prose), " Generate prose";
 
-  "--print-il", Arg.Set print_elab_il, "Print il (after elaboration)";
-  "--print-final-il", Arg.Set print_final_il, "Print final il";
-  "--print-all-il", Arg.Set print_all_il, "Print il after each step";
+  "--print-il", Arg.Set print_elab_il, " Print il (after elaboration)";
+  "--print-final-il", Arg.Set print_final_il, " Print final il";
+  "--print-all-il", Arg.Set print_all_il, " Print il after each step";
 
-  "--sub", Arg.Set pass_sub, "Synthesize explicit subtype coercions";
-  "--totalize", Arg.Set pass_totalize, "Run function totalization";
-  "--the-elimination", Arg.Set pass_unthe, "Eliminate the ! operator in relations";
-  "--sideconditions", Arg.Set pass_sideconditions, "Infer side conditoins";
+  "--sub", Arg.Set pass_sub, " Synthesize explicit subtype coercions";
+  "--totalize", Arg.Set pass_totalize, " Run function totalization";
+  "--the-elimination", Arg.Set pass_unthe, " Eliminate the ! operator in relations";
+  "--sideconditions", Arg.Set pass_sideconditions, " Infer side conditoins";
 
   "-help", Arg.Unit ignore, "";
   "--help", Arg.Unit ignore, "";

--- a/spectec/test-frontend/TEST.md
+++ b/spectec/test-frontend/TEST.md
@@ -770,10 +770,10 @@ relation InstrSeq_ok: `%|-%*:%`(context, instr*, functype)
     -- InstrSeq_ok: `%|-%*:%`(C, [instr_2], `%->%`(t_2*{t_2}, t_3*{t_3}))
 
   ;; 3-typing.watsup:141.1-146.38
-  rule weak {C : context, instr* : instr*, t'_1 : valtype, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
-    `%|-%*:%`(C, instr*{instr}, `%->%`([t'_1], t'_2*{t'_2}))
+  rule weak {C : context, instr* : instr*, t'_1* : valtype*, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
+    `%|-%*:%`(C, instr*{instr}, `%->%`(t'_1*{t'_1}, t'_2*{t'_2}))
     -- InstrSeq_ok: `%|-%*:%`(C, instr*{instr}, `%->%`(t_1*{t_1}, t_2*{t_2}))
-    -- Resulttype_sub: `|-%*<:%*`(t'_1*{}, t_1*{t_1})
+    -- Resulttype_sub: `|-%*<:%*`(t'_1*{t'_1}, t_1*{t_1})
     -- Resulttype_sub: `|-%*<:%*`(t_2*{t_2}, t'_2*{t'_2})
 
   ;; 3-typing.watsup:148.1-150.45
@@ -2187,7 +2187,7 @@ $$
 { \vdash }\;{\mathit{t}_{2}^\ast} \leq {{\mathit{t}'}_{2}^\ast}
 \end{array}
 }{
-\mathit{C} \vdash {\mathit{instr}^\ast} : {\mathit{t}'}_{1} \rightarrow {{\mathit{t}'}_{2}^\ast}
+\mathit{C} \vdash {\mathit{instr}^\ast} : {{\mathit{t}'}_{1}^\ast} \rightarrow {{\mathit{t}'}_{2}^\ast}
 } \, {[\textsc{\scriptsize T*{-}weak}]}
 \qquad
 \end{array}

--- a/spectec/test-middlend/TEST.md
+++ b/spectec/test-middlend/TEST.md
@@ -769,10 +769,10 @@ relation InstrSeq_ok: `%|-%*:%`(context, instr*, functype)
     -- InstrSeq_ok: `%|-%*:%`(C, [instr_2], `%->%`(t_2*{t_2}, t_3*{t_3}))
 
   ;; 3-typing.watsup:141.1-146.38
-  rule weak {C : context, instr* : instr*, t'_1 : valtype, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
-    `%|-%*:%`(C, instr*{instr}, `%->%`([t'_1], t'_2*{t'_2}))
+  rule weak {C : context, instr* : instr*, t'_1* : valtype*, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
+    `%|-%*:%`(C, instr*{instr}, `%->%`(t'_1*{t'_1}, t'_2*{t'_2}))
     -- InstrSeq_ok: `%|-%*:%`(C, instr*{instr}, `%->%`(t_1*{t_1}, t_2*{t_2}))
-    -- Resulttype_sub: `|-%*<:%*`(t'_1*{}, t_1*{t_1})
+    -- Resulttype_sub: `|-%*<:%*`(t'_1*{t'_1}, t_1*{t_1})
     -- Resulttype_sub: `|-%*<:%*`(t_2*{t_2}, t'_2*{t'_2})
 
   ;; 3-typing.watsup:148.1-150.45
@@ -2423,10 +2423,10 @@ relation InstrSeq_ok: `%|-%*:%`(context, instr*, functype)
     -- InstrSeq_ok: `%|-%*:%`(C, [instr_2], `%->%`(t_2*{t_2}, t_3*{t_3}))
 
   ;; 3-typing.watsup:141.1-146.38
-  rule weak {C : context, instr* : instr*, t'_1 : valtype, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
-    `%|-%*:%`(C, instr*{instr}, `%->%`([t'_1], t'_2*{t'_2}))
+  rule weak {C : context, instr* : instr*, t'_1* : valtype*, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
+    `%|-%*:%`(C, instr*{instr}, `%->%`(t'_1*{t'_1}, t'_2*{t'_2}))
     -- InstrSeq_ok: `%|-%*:%`(C, instr*{instr}, `%->%`(t_1*{t_1}, t_2*{t_2}))
-    -- Resulttype_sub: `|-%*<:%*`(t'_1*{}, t_1*{t_1})
+    -- Resulttype_sub: `|-%*<:%*`(t'_1*{t'_1}, t_1*{t_1})
     -- Resulttype_sub: `|-%*<:%*`(t_2*{t_2}, t'_2*{t'_2})
 
   ;; 3-typing.watsup:148.1-150.45
@@ -4141,10 +4141,10 @@ relation InstrSeq_ok: `%|-%*:%`(context, instr*, functype)
     -- InstrSeq_ok: `%|-%*:%`(C, [instr_2], `%->%`(t_2*{t_2}, t_3*{t_3}))
 
   ;; 3-typing.watsup:141.1-146.38
-  rule weak {C : context, instr* : instr*, t'_1 : valtype, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
-    `%|-%*:%`(C, instr*{instr}, `%->%`([t'_1], t'_2*{t'_2}))
+  rule weak {C : context, instr* : instr*, t'_1* : valtype*, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
+    `%|-%*:%`(C, instr*{instr}, `%->%`(t'_1*{t'_1}, t'_2*{t'_2}))
     -- InstrSeq_ok: `%|-%*:%`(C, instr*{instr}, `%->%`(t_1*{t_1}, t_2*{t_2}))
-    -- Resulttype_sub: `|-%*<:%*`(t'_1*{}, t_1*{t_1})
+    -- Resulttype_sub: `|-%*<:%*`(t'_1*{t'_1}, t_1*{t_1})
     -- Resulttype_sub: `|-%*<:%*`(t_2*{t_2}, t'_2*{t'_2})
 
   ;; 3-typing.watsup:148.1-150.45
@@ -5869,10 +5869,10 @@ relation InstrSeq_ok: `%|-%*:%`(context, instr*, functype)
     -- InstrSeq_ok: `%|-%*:%`(C, [instr_2], `%->%`(t_2*{t_2}, t_3*{t_3}))
 
   ;; 3-typing.watsup:141.1-146.38
-  rule weak {C : context, instr* : instr*, t'_1 : valtype, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
-    `%|-%*:%`(C, instr*{instr}, `%->%`([t'_1], t'_2*{t'_2}))
+  rule weak {C : context, instr* : instr*, t'_1* : valtype*, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
+    `%|-%*:%`(C, instr*{instr}, `%->%`(t'_1*{t'_1}, t'_2*{t'_2}))
     -- InstrSeq_ok: `%|-%*:%`(C, instr*{instr}, `%->%`(t_1*{t_1}, t_2*{t_2}))
-    -- Resulttype_sub: `|-%*<:%*`(t'_1*{}, t_1*{t_1})
+    -- Resulttype_sub: `|-%*<:%*`(t'_1*{t'_1}, t_1*{t_1})
     -- Resulttype_sub: `|-%*<:%*`(t_2*{t_2}, t'_2*{t'_2})
 
   ;; 3-typing.watsup:148.1-150.45
@@ -7641,10 +7641,10 @@ relation InstrSeq_ok: `%|-%*:%`(context, instr*, functype)
     -- InstrSeq_ok: `%|-%*:%`(C, [instr_2], `%->%`(t_2*{t_2}, t_3*{t_3}))
 
   ;; 3-typing.watsup:141.1-146.38
-  rule weak {C : context, instr* : instr*, t'_1 : valtype, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
-    `%|-%*:%`(C, instr*{instr}, `%->%`([t'_1], t'_2*{t'_2}))
+  rule weak {C : context, instr* : instr*, t'_1* : valtype*, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*}:
+    `%|-%*:%`(C, instr*{instr}, `%->%`(t'_1*{t'_1}, t'_2*{t'_2}))
     -- InstrSeq_ok: `%|-%*:%`(C, instr*{instr}, `%->%`(t_1*{t_1}, t_2*{t_2}))
-    -- Resulttype_sub: `|-%*<:%*`(t'_1*{}, t_1*{t_1})
+    -- Resulttype_sub: `|-%*<:%*`(t'_1*{t'_1}, t_1*{t_1})
     -- Resulttype_sub: `|-%*<:%*`(t_2*{t_2}, t'_2*{t'_2})
 
   ;; 3-typing.watsup:148.1-150.45


### PR DESCRIPTION
Two small changes:

1. I think that there was a `*` missing in the specification. Correct me if I am wrong. 

2. Correctly align help text (and fix a couple of typos) so that we have

```
  -v                 Show version
  -o                 Generate file
  -p                 Patch files
  -d                 Dry run (when -p) 
  -l                 Log execution steps
  -w                 Warn about unused or multiply used splices
  --check            Check only
  --latex            Generate Latex (default)
  --sphinx           Generate Latex for Sphinx
  --prose            Generate prose
  --print-il         Print il (after elaboration)
  --print-final-il   Print final il
  --print-all-il     Print il after each step
  --sub              Synthesize explicit subtype coercions
  --totalize         Run function totalization
  --the-elimination  Eliminate the ! operator in relations
  --sideconditions   Infer side conditions
```

instead of:

```
Usage: watsup [option] [file ...] [-p file ...]
  -v                          Show version
  -o                          Generate file
  -p                          Patch files
  -d                          Dry run (when -p) 
  -l                          Log execution steps
  -w                          Warn about unsed or multiply used splices
  --check                     Check only
  --latex                     Generate Latex (default)
  --sphinx                    Generate Latex for Sphinx
  --prose                     Generate prose
  --print-il Print            il (after elaboration)
  --print-final-il Print      final il
  --print-all-il Print        il after each step
  --sub Synthesize            explicit subtype coercions
  --totalize Run              function totalization
  --the-elimination Eliminate the ! operator in relations
  --sideconditions Infer      side conditoins
```
