### PR TITLE
Suggest spec changes

### DIFF
--- a/spectec/spec/1-syntax.watsup
+++ b/spectec/spec/1-syntax.watsup
@@ -71,7 +71,7 @@ syntax elemtype hint(desc "element type") =
 syntax datatype hint(desc "data type") =
   OK
 syntax externtype hint(desc "external type") =
-  | GLOBAL globaltype | FUNC functype | TABLE tabletype | MEMORY memtype
+  | GLOBAL globaltype | FUNC functype | TABLE tabletype | MEM memtype
 
 var lim : limits
 var ft : functype
@@ -203,11 +203,11 @@ syntax start hint(desc "start function") =
   START funcidx
 
 syntax externuse hint(desc "external use") =
-  | FUNC funcidx | GLOBAL globalidx | TABLE tableidx | MEMORY memidx
+  | FUNC funcidx | GLOBAL globalidx | TABLE tableidx | MEM memidx
 syntax export hint(desc "export") =
   EXPORT name externuse
 syntax import hint(desc "import") =
   IMPORT name name externtype
 
 syntax module hint(desc "module") =
-  MODULE import* func* global* table* mem* elem* data* start* export*
+  MODULE import* func* global* table* mem* elem* data* start? export*

--- a/spectec/spec/3-typing.watsup
+++ b/spectec/spec/3-typing.watsup
@@ -51,7 +51,7 @@ rule Externtype_ok/table:
   -- Tabletype_ok: |- tabletype : OK
 
 rule Externtype_ok/mem:
-  |- MEMORY memtype : OK
+  |- MEM memtype : OK
   -- Memtype_ok: |- memtype : OK
 
 
@@ -113,7 +113,7 @@ rule Externtype_sub/table:
   -- Tabletype_sub: |- tt_1 <: tt_2
 
 rule Externtype_sub/mem:
-  |- MEMORY mt_1 <: MEMORY mt_2
+  |- MEM mt_1 <: MEM mt_2
   -- Memtype_sub: |- mt_1 <: mt_2
 
 
@@ -477,14 +477,14 @@ rule Externuse_ok/table:
   -- if C.TABLE[x] = tt
 
 rule Externuse_ok/mem:
-  C |- MEMORY x : MEMORY mt
+  C |- MEM x : MEM mt
   -- if C.MEM[x] = mt
 
 
 relation Module_ok: |- module : OK      hint(show "T-module")
 
 rule Module_ok:
-  |- MODULE import* func* global* table* mem* elem* data^n start* export* : OK
+  |- MODULE import* func* global* table* mem* elem* data^n start? export* : OK
   ;; TODO: incremental contexts for globals
   -- if C = {FUNC ft*, GLOBAL gt*, TABLE tt*, MEM mt*, ELEM rt*, DATA OK^n}
 
@@ -495,8 +495,7 @@ rule Module_ok:
 
   -- (Elem_ok: C |- elem : rt)*
   -- (Data_ok: C |- data : OK)^n
-  -- (Start_ok: C |- start : OK)*
+  -- (Start_ok: C |- start : OK)?
 
   -- if |mem*| <= 1
-  -- if |start*| <= 1
   ;; -- TODO: disjoint export names

--- a/spectec/spec/4-runtime.watsup
+++ b/spectec/spec/4-runtime.watsup
@@ -46,7 +46,8 @@ def $default_(I32) = (CONST I32 0)
 def $default_(I64) = (CONST I64 0)
 def $default_(F32) = (CONST F32 0)
 def $default_(F64) = (CONST F64 0)
-def $default_(rt) = (REF.NULL rt)
+def $default_(FUNCREF) = (REF.NULL FUNCREF)
+def $default_(EXTERNREF) = (REF.NULL EXTERNREF)
 
 
 ;; Configurations

--- a/spectec/spec/4-runtime.watsup
+++ b/spectec/spec/4-runtime.watsup
@@ -47,7 +47,7 @@ def $default_(I64) = (CONST I64 0)
 def $default_(F32) = (CONST F32 0)
 def $default_(F64) = (CONST F64 0)
 def $default_(FUNCREF) = (REF.NULL FUNCREF)
-def $default_(EXTERNREF) = (REF.NULL EXTERNREF)
+def $default_(EXTERNREF) = (REF.NULL EXTERNREF) ;; TODO: All referece types should be caught by one pattern.
 
 
 ;; Configurations

--- a/spectec/spec/4-runtime.watsup
+++ b/spectec/spec/4-runtime.watsup
@@ -47,7 +47,7 @@ def $default_(I64) = (CONST I64 0)
 def $default_(F32) = (CONST F32 0)
 def $default_(F64) = (CONST F64 0)
 def $default_(FUNCREF) = (REF.NULL FUNCREF)
-def $default_(EXTERNREF) = (REF.NULL EXTERNREF) ;; TODO: All referece types should be caught by one pattern.
+def $default_(EXTERNREF) = (REF.NULL EXTERNREF) ;; TODO: All reference types should be caught by one pattern.
 
 
 ;; Configurations


### PR DESCRIPTION
1. MEMORY -> MEM
Currently, DSL uses the name `MEMORY` for both `externtype` and `externuse`. I think it would be better to change this into `MEM`, so that it matches with the current spec, and also matches with `externval` in '4-runtime.watsup".

2. Explicit pattern match for `$default_` function
Implicitly using the typed-identifier `rt` as a pattern for argument of `$default_` function caused inconvenience to several backends, so it was propsed to use explicit pattern match with `FUNCREF` and `EXTERNREF`. I also believe that the proposed version is also easier for a human to understand.

3. Optional start function
This is actually a question rather than a suggestion, but is it intended that DSL defines the start function of a module as a list, not an option? (I presume that the intention was to allow multiple start functions in the future.)