### PR TITLE
sideconditions: fix nested iteration

### DIFF
--- a/spectec/test-middlend/TEST.md
+++ b/spectec/test-middlend/TEST.md
@@ -14320,3 +14320,105 @@ def invoke : (store, funcaddr, val*) -> config
 == IL Validation after pass animate...
 == Complete.
 ```
+# More tricky tests
+
+```sh
+$ (cd ../test-middlend; ../src/exe-watsup/main.exe test.watsup -l --print-all-il --all-passes --check)
+== Parsing...
+== Elaboration...
+
+;; test.watsup:5.1-5.29
+relation HasSize: `%|-%`(nat, nat)
+
+;; test.watsup:6.1-6.41
+relation TestNestedIter: `**%*|-*%*`(nat***, nat**)
+  ;; test.watsup:11.1-13.21
+  rule _ {m*+ : nat*+, n**+ : nat**+}:
+    `**%*|-*%*`(n*{n}*{n}+{n}, m*{m}+{m})
+    -- (if (|n*{n}| = m))*{m n}+{m n}
+
+== IL Validation...
+== Running pass sub...
+
+;; test.watsup:5.1-5.29
+relation HasSize: `%|-%`(nat, nat)
+
+;; test.watsup:6.1-6.41
+relation TestNestedIter: `**%*|-*%*`(nat***, nat**)
+  ;; test.watsup:11.1-13.21
+  rule _ {m*+ : nat*+, n**+ : nat**+}:
+    `**%*|-*%*`(n*{n}*{n}+{n}, m*{m}+{m})
+    -- (if (|n*{n}| = m))*{m n}+{m n}
+
+== IL Validation after pass sub...
+== Running pass totalize...
+
+;; test.watsup:5.1-5.29
+relation HasSize: `%|-%`(nat, nat)
+
+;; test.watsup:6.1-6.41
+relation TestNestedIter: `**%*|-*%*`(nat***, nat**)
+  ;; test.watsup:11.1-13.21
+  rule _ {m*+ : nat*+, n**+ : nat**+}:
+    `**%*|-*%*`(n*{n}*{n}+{n}, m*{m}+{m})
+    -- (if (|n*{n}| = m))*{m n}+{m n}
+
+== IL Validation after pass totalize...
+== Running pass the-elimination...
+
+;; test.watsup:5.1-5.29
+relation HasSize: `%|-%`(nat, nat)
+
+;; test.watsup:6.1-6.41
+relation TestNestedIter: `**%*|-*%*`(nat***, nat**)
+  ;; test.watsup:11.1-13.21
+  rule _ {m*+ : nat*+, n**+ : nat**+}:
+    `**%*|-*%*`(n*{n}*{n}+{n}, m*{m}+{m})
+    -- (if (|n*{n}| = m))*{m n}+{m n}
+
+== IL Validation after pass the-elimination...
+== Running pass wildcards...
+
+;; test.watsup:5.1-5.29
+relation HasSize: `%|-%`(nat, nat)
+
+;; test.watsup:6.1-6.41
+relation TestNestedIter: `**%*|-*%*`(nat***, nat**)
+  ;; test.watsup:11.1-13.21
+  rule _ {m*+ : nat*+, n**+ : nat**+}:
+    `**%*|-*%*`(n*{n}*{n}+{n}, m*{m}+{m})
+    -- (if (|n*{n}| = m))*{m n}+{m n}
+
+== IL Validation after pass wildcards...
+== Running pass sideconditions...
+
+;; test.watsup:5.1-5.29
+relation HasSize: `%|-%`(nat, nat)
+
+;; test.watsup:6.1-6.41
+relation TestNestedIter: `**%*|-*%*`(nat***, nat**)
+  ;; test.watsup:11.1-13.21
+  rule _ {m*+ : nat*+, n**+ : nat**+}:
+    `**%*|-*%*`(n*{n}*{n}+{n}, m*{m}+{m})
+    -- if (|m*{m}+{m}| = |n*{n}*{n}+{n}|)
+    -- (if (|m*{m}| = |n*{n}*{n}|))+{m n}
+    -- (if (|n*{n}| = m))*{m n}+{m n}
+
+== IL Validation after pass sideconditions...
+== Running pass animate...
+
+;; test.watsup:5.1-5.29
+relation HasSize: `%|-%`(nat, nat)
+
+;; test.watsup:6.1-6.41
+relation TestNestedIter: `**%*|-*%*`(nat***, nat**)
+  ;; test.watsup:11.1-13.21
+  rule _ {m*+ : nat*+, n**+ : nat**+}:
+    `**%*|-*%*`(n*{n}*{n}+{n}, m*{m}+{m})
+    -- if (|m*{m}+{m}| = |n*{n}*{n}+{n}|)
+    -- (if (|m*{m}| = |n*{n}*{n}|))+{m n}
+    -- (if (|n*{n}| = m))*{m n}+{m n}
+
+== IL Validation after pass animate...
+== Complete.
+```

--- a/spectec/test-middlend/dune
+++ b/spectec/test-middlend/dune
@@ -3,6 +3,7 @@
   (deps
     (file ../src/exe-watsup/main.exe)
     (glob_files ../spec/*.watsup)
+    (glob_files *.watsup)
   )
   (files TEST.md)
 )

--- a/spectec/test-middlend/test.watsup
+++ b/spectec/test-middlend/test.watsup
@@ -1,0 +1,13 @@
+;;
+;; some tricky definitions to test the transformations
+;;
+
+relation HasSize: nat |- nat
+relation TestNestedIter: nat*** |- nat**
+
+var n : nat
+var m : nat
+
+rule TestNestedIter:
+  n**+ |- m*+
+  -- if (|n*| = m)*+


### PR DESCRIPTION
@rossberg found some bugs on the `wasm3` branch; this fixes them and
adds a dedicated test case, separte from `spec/` to `test-middlend`
