### PR TITLE
Implement grammar definitions

### DIFF
--- a/spectec/spec/1-syntax.watsup
+++ b/spectec/spec/1-syntax.watsup
@@ -10,17 +10,23 @@ var k : nat
 var N : nat
 var M : nat
 
+var ii : int hint(show i)
+
 
 ;; Values
 
 syntax byte hint(desc "byte") = 0x00 | ... | 0xFF
 
+;; TODO: make u(N), s(N), i(N)
 syntax uN hint(desc "unsigned integer") = 0 | ... | 2^N-1
-syntax sN hint(desc "signed integer") = -2^(N-1) | ... | -1 | 0 | 1 | ... | 2^(N-1)-1
+syntax sN hint(desc "signed integer") = -2^(N-1) | ... | -1 | 0 | +1 | ... | 2^(N-1)-1
 syntax iN hint(desc "integer") = uN
 
+;; TODO: use u(N), s(N)
 syntax u32 hint(desc "32-bit integer") = 0 | ... | 2^32-1
 syntax u64 hint(desc "64-bit integer") = 0 | ... | 2^64-1
+syntax u128 hint(desc "128-bit integer") = 0 | ... | 2^128-1
+syntax s33 hint(desc "33-bit signed integer") = -2^32 | ... | 2^32-1
 
 var b : byte
 
@@ -39,13 +45,25 @@ def $M(N) = $signif(N)
 def $E(N) : nat  hint(show $E_(%))
 def $E(N) = $expon(N)
 
+;; TODO: make f(N), fmag(N)
 syntax fN hint(desc "floating-point number") = | POS fNmag  hint(show $(+%)) | NEG fNmag  hint(show $(-%))
 
 syntax fNmag hint(desc "floating-point magnitude") =
-  | NORM m n     hint(show $((1 + %*2^(-$M(N))) * 2^%))  -- if $(-2^($E(N)-1)+2 <= n <= 2^($E(N)-1)-1)
-  | SUBNORM m n  hint(show $((0 + %*2^(-$M(N))) * 2^%))  -- if $(-2^($E(N)-1)+2 = n)
+  | NORM m n     hint(show $((1 + %*2^(-$M(N))) * 2^%))  -- if $(2-2^($E(N)-1) <= n <= 2^($E(N)-1)-1)
+  | SUBNORM m n  hint(show $((0 + %*2^(-$M(N))) * 2^%))  -- if $(2-2^($E(N)-1) = n)
   | INF          hint(show infinity)
-  | NAN n        hint(show NAN#((%)))                -- if $(1 <= n < $M(N))
+  | NAN n        hint(show NAN#((%)))                    -- if $(1 <= n < $M(N))
+
+;; TODO: use f(N)
+def $fNzero : fN  hint(show $(+0))
+def $fNzero = POS (NORM 0 0)
+
+;; TODO: use f(N)
+syntax f32 hint(desc "32-bit floating-point") = fN
+syntax f64 hint(desc "64-bit floating-point") = fN
+
+var p : fN
+var q : fN
 
 
 ;; Names
@@ -54,10 +72,13 @@ syntax char hint(desc "character") = U+0000 | ... | U+D7FF | U+E000 | ... | U+10
 
 syntax name hint(desc "name") = char*
 
+var nm : name
+
 
 ;; Indices
 
-syntax idx hint(desc "index") = nat
+syntax idx hint(desc "index") = u32
+syntax typeidx hint(desc "type index") = idx
 syntax funcidx hint(desc "function index") = idx
 syntax globalidx hint(desc "global index") = idx
 syntax tableidx hint(desc "table index") = idx
@@ -94,10 +115,12 @@ var rt : reftype
 syntax resulttype hint(desc "result type") =
   valtype*
 
+syntax mut = MUT?
+
 syntax limits hint(desc "limits") =
   `[u32 .. u32]
 syntax globaltype hint(desc "global type") =
-  MUT? valtype
+  mut valtype
 syntax functype hint(desc "function type") =
   resulttype -> resulttype
 syntax tabletype hint(desc "table type") =
@@ -109,7 +132,7 @@ syntax elemtype hint(desc "element type") =
 syntax datatype hint(desc "data type") =
   OK
 syntax externtype hint(desc "external type") =
-  | GLOBAL globaltype | FUNC functype | TABLE tabletype | MEM memtype
+  | FUNC functype | GLOBAL globaltype | TABLE tabletype | MEM memtype
 
 var lim : limits
 var ft : functype
@@ -150,20 +173,29 @@ var testop : testop_numtype
 var relop : relop_numtype
 
 
+syntax memop hint(desc "memory operator") = {ALIGN u32, OFFSET u32}
+
+var mo:memop
+
+
 ;; Instructions
 
+;; TODO: do c(numtype)?
 syntax c_numtype = nat  ;; TODO
 syntax c_vectype = nat  ;; TODO
 var c : c_numtype
 
-syntax blocktype hint(desc "block type") = functype  ;; TODO
+syntax blocktype hint(desc "block type") =
+  | _RESULT valtype?
+  | _IDX funcidx
+
 var bt : blocktype
 
 syntax instr/control hint(desc "control instruction") =
   | UNREACHABLE
   | NOP
   | DROP
-  | SELECT valtype?
+  | SELECT (valtype*)?
   | BLOCK blocktype instr*
   | LOOP blocktype instr*
   | IF blocktype instr* ELSE instr*
@@ -171,7 +203,7 @@ syntax instr/control hint(desc "control instruction") =
   | BR_IF labelidx
   | BR_TABLE labelidx* labelidx
   | CALL funcidx
-  | CALL_INDIRECT tableidx functype
+  | CALL_INDIRECT tableidx typeidx
   | RETURN
   | ...
 
@@ -220,8 +252,8 @@ syntax instr/memory hint(desc "memory instruction") = ...
   | MEMORY.COPY
   | MEMORY.INIT dataidx
   | DATA.DROP dataidx
-  | LOAD numtype (n _ sx)? u32 u32  hint(show %.LOAD % % %)  hint(show %.LOAD#% % %)
-  | STORE numtype n? u32 u32        hint(show %.STORE % % %) hint(show %.STORE#% % %)
+  | LOAD numtype (n _ sx)? memop  hint(show %.LOAD % %)  hint(show %.LOAD#% %)
+  | STORE numtype n? memop        hint(show %.STORE % %) hint(show %.STORE#% %)
 
 syntax expr hint(desc "expression") =
   instr*
@@ -242,7 +274,7 @@ syntax type hint(desc "type") =
 syntax local hint(desc "local") =
   LOCAL valtype
 syntax func hint(desc "function") =
-  FUNC functype local* expr
+  FUNC typeidx local* expr
 syntax global hint(desc "global") =
   GLOBAL globaltype expr
 syntax table hint(desc "table") =
@@ -264,4 +296,14 @@ syntax import hint(desc "import") =
   IMPORT name name externtype
 
 syntax module hint(desc "module") =
-  MODULE import* func* global* table* mem* elem* data* start? export*
+  MODULE type* import* func* global* table* mem* elem* data* start* export*
+
+
+var ty : type
+var loc : local
+var glob : global
+var tab : table
+var im : import
+var ex : export
+var st : start
+var xx : externidx

--- a/spectec/spec/2-aux.watsup
+++ b/spectec/spec/2-aux.watsup
@@ -15,6 +15,10 @@ def $min(0, j) = 0
 def $min(i, 0) = 0
 def $min($(i+1), $(j+1)) = $min(i, j)
 
+def $sum(nat*) : nat  ;; TODO: hint
+def $sum(epsilon) = 0
+def $sum(n n'*) = $(n + $sum(n'*))
+
 
 ;;
 ;; Auxiliary Definitions on Types
@@ -30,6 +34,48 @@ def $size(I64) = 64
 def $size(F32) = 32
 def $size(F64) = 64
 def $size(V128) = 128
+
+
+;;
+;; Numeric functions
+;;
+
+def $signed(N, nat) : int       hint(show $signed_(%,%))
+def $signed(N, i) = i           -- if $(0 <= 2^(N-1))
+def $signed(N, i) = $(i - 2^N)  -- if $(2^(N-1) <= i < 2^N)
+
+def $invsigned(N, int) : nat    hint(show $signed^(-1)#_%#(%))
+def $invsigned(N, i) = j        -- if $signed(N, j) = i
+
+
+;;
+;; Shorthands for instructions
+;;
+
+def $memop0 : memop  hint(show )
+def $memop0 = {ALIGN 0, OFFSET 0}
+
+
+;; Free indices
+
+def $free_dataidx_instr(instr) : dataidx*  hint(show $free_dataidx)
+def $free_dataidx_instr(MEMORY.INIT x) = x
+def $free_dataidx_instr(DATA.DROP x) = x
+def $free_dataidx_instr(in) = epsilon
+
+def $free_dataidx_instrs(instr*) : dataidx*  hint(show $free_dataidx)
+def $free_dataidx_instrs(epsilon) = epsilon
+def $free_dataidx_instrs(instr instr'*) = $free_dataidx_instr(instr) $free_dataidx_instrs(instr'*)
+
+def $free_dataidx_expr(expr) : dataidx*  hint(show $free_dataidx)
+def $free_dataidx_expr(in*) = $free_dataidx_instrs(in*)
+
+def $free_dataidx_func(func) : dataidx*  hint(show $free_dataidx)
+def $free_dataidx_func(FUNC x loc* e) = $free_dataidx_expr(e)
+
+def $free_dataidx_funcs(func*) : dataidx*  hint(show $free_dataidx)
+def $free_dataidx_funcs(epsilon) = epsilon
+def $free_dataidx_funcs(func func'*) = $free_dataidx_func(func) $free_dataidx_funcs(func'*)
 
 
 ;;

--- a/spectec/spec/3-typing.watsup
+++ b/spectec/spec/3-typing.watsup
@@ -3,7 +3,7 @@
 ;;
 
 syntax context hint(desc "context") =
-  { FUNC functype*, GLOBAL globaltype*, TABLE tabletype*, MEM memtype*,
+  { TYPE functype*, FUNC functype*, GLOBAL globaltype*, TABLE tabletype*, MEM memtype*,
     ELEM elemtype*, DATA datatype*,
     LOCAL valtype*, LABEL resulttype*, RETURN resulttype? }
 
@@ -191,9 +191,16 @@ rule Instr_ok/select-impl:
 
 relation Blocktype_ok: context |- blocktype : functype hint(show "K-block")
 
-rule Blocktype_ok:
-  C |- ft : ft
-  -- Functype_ok: |- ft : OK
+rule Blocktype_ok/void:
+  C |- _RESULT epsilon : epsilon -> epsilon
+
+rule Blocktype_ok/result:
+  C |- _RESULT t : epsilon -> t
+
+rule Blocktype_ok/typeidx:
+  C |- _IDX x : ft
+  -- if C.TYPE[x] = ft
+
 
 rule Instr_ok/block:
   C |- BLOCK bt instr* : t_1* -> t_2*
@@ -239,9 +246,9 @@ rule Instr_ok/call:
   -- if C.FUNC[x] = t_1* -> t_2*
 
 rule Instr_ok/call_indirect:
-  C |- CALL_INDIRECT x ft : t_1* I32 -> t_2*
+  C |- CALL_INDIRECT x y : t_1* I32 -> t_2*
   -- if C.TABLE[x] = lim FUNCREF
-  -- if ft = t_1* -> t_2*
+  -- if C.TYPE[y] = t_1* -> t_2*
 
 
 ;; Numeric instructions
@@ -313,7 +320,7 @@ rule Instr_ok/local.tee:
 
 rule Instr_ok/global.get:
   C |- GLOBAL.GET x : epsilon -> t
-  -- if C.GLOBAL[x] = MUT? t
+  -- if C.GLOBAL[x] = mut t
 
 rule Instr_ok/global.set:
   C |- GLOBAL.SET x : t -> epsilon
@@ -385,14 +392,14 @@ rule Instr_ok/data.drop:
   -- if C.DATA[x] = OK
 
 rule Instr_ok/load:
-  C |- LOAD nt (n _ sx)? n_A n_O : I32 -> nt
+  C |- LOAD nt (n _ sx)? {ALIGN n_A, OFFSET n_O} : I32 -> nt
   -- if C.MEM[0] = mt
   -- if $(2^(n_A) <= $size(nt)/8)
   -- if $(2^(n_A) <= n/8 < $size(nt)/8)?
   -- if n? = epsilon \/ nt = inn
 
 rule Instr_ok/store:
-  C |- STORE nt n? n_A n_O : I32 nt -> epsilon
+  C |- STORE nt n? {ALIGN n_A, OFFSET n_O} : I32 nt -> epsilon
   -- if C.MEM[0] = mt
   -- if $(2^(n_A) <= $size(nt)/8)
   -- if $(2^(n_A) <= n/8 < $size(nt)/8)?
@@ -435,6 +442,7 @@ rule Expr_ok_const:
 ;; Modules
 ;;
 
+relation Type_ok: |- type : functype                 hint(show "T-type")
 relation Func_ok: context |- func : functype         hint(show "T-func")
 relation Global_ok: context |- global : globaltype   hint(show "T-global")
 relation Table_ok: context |- table : tabletype      hint(show "T-table")
@@ -448,16 +456,20 @@ relation Start_ok: context |- start : OK             hint(show "T-start")
 
 ;; Module definitions
 
+rule Type_ok:
+  |- TYPE ft : ft
+  -- Functype_ok: |- ft : OK
+
 rule Func_ok:
-  C |- FUNC ft (LOCAL t)* expr : ft
-  -- if ft = t_1* -> t_2*
+  C |- FUNC x (LOCAL t)* expr : ft
+  -- if C.TYPE[x] = t_1* -> t_2*
   -- Functype_ok: |- ft : OK
   -- Expr_ok: C, LOCAL t_1* t*, LABEL (t_2*), RETURN (t_2*) |- expr : t_2*
 
 rule Global_ok:
   C |- GLOBAL gt expr : gt
   -- Globaltype_ok: |- gt : OK
-  -- if gt = MUT? t
+  -- if gt = mut t
   -- Expr_ok_const: C |- expr : t CONST
 
 rule Table_ok:
@@ -538,10 +550,11 @@ rule Externidx_ok/mem:
 relation Module_ok: |- module : OK      hint(show "T-module")
 
 rule Module_ok:
-  |- MODULE import* func* global* table* mem* elem* data^n start? export* : OK
+  |- MODULE type* import* func* global* table* mem* elem* data^n start? export* : OK
   ;; TODO: incremental contexts for globals
-  -- if C = {FUNC ft*, GLOBAL gt*, TABLE tt*, MEM mt*, ELEM rt*, DATA OK^n}
+  -- if C = {TYPE ft'*, FUNC ft*, GLOBAL gt*, TABLE tt*, MEM mt*, ELEM rt*, DATA OK^n}
 
+  -- (Type_ok: |- type : ft')*
   -- (Func_ok: C |- func : ft)*
   -- (Global_ok: C |- global : gt)*
   -- (Table_ok: C |- table : tt)*

--- a/spectec/spec/4-runtime.watsup
+++ b/spectec/spec/4-runtime.watsup
@@ -68,7 +68,8 @@ def $default_(EXTERNREF) = (REF.NULL EXTERNREF) ;; TODO: All reference types sho
 ;; Instances
 
 syntax funcinst hint(desc "function instance") =
-  { MODULE moduleinst,
+  { TYPE functype,
+    MODULE moduleinst,
     CODE func }
 syntax globalinst hint(desc "global instance") =
   { TYPE globaltype,
@@ -89,7 +90,8 @@ syntax exportinst hint(desc "export instance") =
     VALUE externval }
 
 syntax moduleinst hint(desc "module instance") =
-  { FUNC funcaddr*,
+  { TYPE functype*,
+    FUNC funcaddr*,
     GLOBAL globaladdr*,
     TABLE tableaddr*,
     MEM memaddr*,
@@ -148,6 +150,7 @@ def $meminst((s; f)) = s.MEM
 def $eleminst((s; f)) = s.ELEM
 def $datainst((s; f)) = s.DATA
 
+def $type(state, typeidx) : functype        hint(show %.TYPE#`[%])
 def $func(state, funcidx) : funcinst        hint(show %.FUNC#`[%])
 def $global(state, globalidx) : globalinst  hint(show %.GLOBAL#`[%])
 def $table(state, tableidx) : tableinst     hint(show %.TABLE#`[%])
@@ -156,6 +159,7 @@ def $elem(state, tableidx) : eleminst       hint(show %.ELEM#`[%])
 def $data(state, dataidx) : datainst        hint(show %.DATA#`[%])
 def $local(state, localidx) : val           hint(show %.LOCAL#`[%])
 
+def $type((s; f), x) = f.MODULE.TYPE[x]
 def $func((s; f), x) = s.FUNC[f.MODULE.FUNC[x]]
 def $global((s; f), x) = s.GLOBAL[f.MODULE.GLOBAL[x]]
 def $table((s; f), x) = s.TABLE[f.MODULE.TABLE[x]]

--- a/spectec/spec/5-numerics.watsup
+++ b/spectec/spec/5-numerics.watsup
@@ -10,4 +10,12 @@ def $cvtop(numtype, cvtop, numtype, sx?, c) : c_numtype* hint(show $ext_(%,%)^%(
 
 def $wrap_((nat, nat), c) : nat
 
-def $bytes_(nat, c) : byte*
+def $ibytes(N, iN) : byte*        hint(show $bytes_(f#%,%))
+def $fbytes(N, fN) : byte*        hint(show $bytes_(f#%,%))
+def $ntbytes(numtype, c) : byte*  hint(show $bytes_(%,%))
+
+def $invibytes(N, byte*) : iN
+def $invfbytes(N, byte*) : fN
+
+def $invibytes(N, b*) = n  -- if $ibytes(N, n) = b*
+def $invfbytes(N, b*) = p  -- if $fbytes(N, p) = b*

--- a/spectec/spec/6-reduction.watsup
+++ b/spectec/spec/6-reduction.watsup
@@ -32,23 +32,28 @@ rule Step_pure/drop:
 
 
 rule Step_pure/select-true:
-  val_1 val_2 (CONST I32 c) (SELECT t?)  ~>  val_1
+  val_1 val_2 (CONST I32 c) (SELECT t*?)  ~>  val_1
   -- if c =/= 0
 
 rule Step_pure/select-false:
-  val_1 val_2 (CONST I32 c) (SELECT t?)  ~>  val_2
+  val_1 val_2 (CONST I32 c) (SELECT t*?)  ~>  val_2
   -- if c = 0
 
 
 ;; Block instructions
 
-rule Step_pure/block:
-  val^k (BLOCK bt instr*)  ~>  (LABEL_ n `{epsilon} val^k instr*)
-  -- if bt = t_1^k -> t_2^n
+def $blocktype(state, blocktype) : functype  hint(show $blocktype_(%,%))
+def $blocktype(z, _RESULT epsilon) = epsilon -> epsilon
+def $blocktype(z, _RESULT t) = epsilon -> t
+def $blocktype(z, _IDX x) = $type(z, x)
 
-rule Step_pure/loop:
-  val^k (LOOP bt instr*)  ~>  (LABEL_ k `{LOOP bt instr*} val^k instr*)
-  -- if bt = t_1^k -> t_2^n
+rule Step_read/block:
+  z; val^k (BLOCK bt instr*)  ~>  (LABEL_ n `{epsilon} val^k instr*)
+  -- if $blocktype(z, bt) = t_1^k -> t_2^n
+
+rule Step_read/loop:
+  z; val^k (LOOP bt instr*)  ~>  (LABEL_ k `{LOOP bt instr*} val^k instr*)
+  -- if $blocktype(z, bt) = t_1^k -> t_2^n
 
 rule Step_pure/if-true:
   (CONST I32 c) (IF bt instr_1* ELSE instr_2*)  ~>  (BLOCK bt instr_1*)
@@ -97,19 +102,19 @@ rule Step_read/call:
   z; (CALL x)  ~>  (CALL_ADDR $funcaddr(z)[x])  ;; TODO
 
 rule Step_read/call_indirect-call:
-  z; (CONST I32 i) (CALL_INDIRECT x ft)  ~>  (CALL_ADDR a)
+  z; (CONST I32 i) (CALL_INDIRECT x y)  ~>  (CALL_ADDR a)
   -- if $table(z, x).ELEM[i] = (REF.FUNC_ADDR a)
-  -- if $funcinst(z)[a].CODE = FUNC ft' (LOCAL t)* instr*
-  -- if ft = ft'
+  -- if $funcinst(z)[a].CODE = FUNC y' (LOCAL t)* instr*
+  -- if C.TYPE[y] = C.TYPE[y']
 
 rule Step_read/call_indirect-trap:
-  z; (CONST I32 i) (CALL_INDIRECT x ft)  ~>  TRAP
+  z; (CONST I32 i) (CALL_INDIRECT x y)  ~>  TRAP
   -- otherwise
 
 rule Step_read/call_addr:
   z; val^k (CALL_ADDR a)  ~>  (FRAME_ n `{f} (LABEL_ n `{epsilon} instr*))
-  -- if $funcinst(z)[a] = {MODULE mm, CODE func}
-  -- if func = FUNC (t_1^k -> t_2^n) (LOCAL t)* instr*
+  -- if $funcinst(z)[a] = {TYPE (t_1^k -> t_2^n), MODULE mm, CODE func}
+  -- if func = FUNC x (LOCAL t)* instr*
   -- if f = {LOCAL val^k ($default_(t))*, MODULE mm}
 
 
@@ -230,7 +235,7 @@ rule Step/table.grow-succeed:
   -- if $grow_table($table(z, x), n, ref) = ti
 
 rule Step/table.grow-fail:
-  z; ref (CONST I32 n) (TABLE.GROW x)  ~>  z; (CONST I32 $(-1))
+  z; ref (CONST I32 n) (TABLE.GROW x)  ~>  z; (CONST I32 $invsigned(32, $(-1)))
 
 
 rule Step_read/table.fill-trap:
@@ -295,37 +300,37 @@ rule Step/elem.drop:
 ;; Memory instructions
 
 rule Step_read/load-num-trap:
-  z; (CONST I32 i) (LOAD nt n_A n_O)  ~>  TRAP
-  -- if $(i + n_O + $size(nt)/8 > |$mem(z, 0).DATA|)
+  z; (CONST I32 i) (LOAD nt mo)  ~>  TRAP
+  -- if $(i + mo.OFFSET + $size(nt)/8 > |$mem(z, 0).DATA|)
 
 rule Step_read/load-num-val:
-  z; (CONST I32 i) (LOAD nt n_A n_O)  ~>  (CONST nt c)
-  -- if $bytes_($size(nt), c) = $mem(z, 0).DATA[i + n_O : $size(nt)/8]
+  z; (CONST I32 i) (LOAD nt mo)  ~>  (CONST nt c)
+  -- if $ntbytes(nt, c) = $mem(z, 0).DATA[i + mo.OFFSET : $size(nt)/8]
 
 rule Step_read/load-pack-trap:
-  z; (CONST I32 i) (LOAD nt (n _ sx) n_A n_O)  ~>  TRAP
-  -- if $(i + n_O + n/8 > |$mem(z, 0).DATA|)
+  z; (CONST I32 i) (LOAD nt (n _ sx) mo)  ~>  TRAP
+  -- if $(i + mo.OFFSET + n/8 > |$mem(z, 0).DATA|)
 
 rule Step_read/load-pack-val:
-  z; (CONST I32 i) (LOAD nt (n _ sx) n_A n_O)  ~>  (CONST nt $ext(n, $size(nt), sx, c))
-  -- if $bytes_(n, c) = $mem(z, 0).DATA[i + n_O : n/8]
+  z; (CONST I32 i) (LOAD nt (n _ sx) mo)  ~>  (CONST nt $ext(n, $size(nt), sx, c))
+  -- if $ibytes(n, c) = $mem(z, 0).DATA[i + mo.OFFSET : n/8]
 
 
 rule Step/store-num-trap:
-  z; (CONST I32 i) (CONST nt c) (STORE nt n_A n_O)  ~>  z; TRAP
-  -- if $(i + n_O + $size(nt)/8) > |$mem(z, 0).DATA|
+  z; (CONST I32 i) (CONST nt c) (STORE nt mo)  ~>  z; TRAP
+  -- if $(i + mo.OFFSET + $size(nt)/8) > |$mem(z, 0).DATA|
 
 rule Step/store-num-val:
-  z; (CONST I32 i) (CONST nt c) (STORE nt n_A n_O)  ~>  $with_mem(z, 0, $(i + n_O), $($size(nt)/8), b*); epsilon
-  -- if b* = $bytes_($size(nt), c)
+  z; (CONST I32 i) (CONST nt c) (STORE nt mo)  ~>  $with_mem(z, 0, $(i + mo.OFFSET), $($size(nt)/8), b*); epsilon
+  -- if b* = $ntbytes(nt, c)
 
 rule Step/store-pack-trap:
-  z; (CONST I32 i) (CONST nt c) (STORE nt n n_A n_O)  ~>  z; TRAP
-  -- if $(i + n_O + n/8) > |$mem(z, 0).DATA|
+  z; (CONST I32 i) (CONST nt c) (STORE nt n mo)  ~>  z; TRAP
+  -- if $(i + mo.OFFSET + n/8) > |$mem(z, 0).DATA|
 
 rule Step/store-pack-val:
-  z; (CONST I32 i) (CONST nt c) (STORE nt n n_A n_O)  ~>  $with_mem(z, 0, $(i + n_O), $(n/8), b*); epsilon
-  -- if b* = $bytes_(n, $wrap_(($size(nt),n), c))
+  z; (CONST I32 i) (CONST nt c) (STORE nt n mo)  ~>  $with_mem(z, 0, $(i + mo.OFFSET), $(n/8), b*); epsilon
+  -- if b* = $ibytes(n, $wrap_(($size(nt),n), c))
 
 
 rule Step_read/memory.size:
@@ -338,7 +343,7 @@ rule Step/memory.grow-succeed:
   -- if $grow_memory($mem(z, 0), n) = mi
 
 rule Step/memory.grow-fail:
-  z; (CONST I32 n) (MEMORY.GROW)  ~>  z; (CONST I32 $(-1))
+  z; (CONST I32 n) (MEMORY.GROW)  ~>  z; (CONST I32 $invsigned(32, $(-1)))
 
 
 rule Step_read/memory.fill-trap:
@@ -352,7 +357,7 @@ rule Step_read/memory.fill-zero:
 
 rule Step_read/memory.fill-succ:
   z; (CONST I32 i) val (CONST I32 n) (MEMORY.FILL)  ~>
-    (CONST I32 i) val (STORE I32 8 0 0)
+    (CONST I32 i) val (STORE I32 8 $memop0)
     (CONST I32 $(i+1)) val (CONST I32 $(n-1)) (MEMORY.FILL)
   -- otherwise
 
@@ -368,14 +373,14 @@ rule Step_read/memory.copy-zero:
 
 rule Step_read/memory.copy-le:
   z; (CONST I32 j) (CONST I32 i) (CONST I32 n) (MEMORY.COPY)  ~>
-    (CONST I32 j) (CONST I32 i) (LOAD I32 (8 _ U) 0 0) (STORE I32 8 0 0)
+    (CONST I32 j) (CONST I32 i) (LOAD I32 (8 _ U) $memop0) (STORE I32 8 $memop0)
     (CONST I32 $(j+1)) (CONST I32 $(i+1)) (CONST I32 $(n-1)) (MEMORY.COPY)
   -- otherwise
   -- if j <= i
 
 rule Step_read/memory.copy-gt:
   z; (CONST I32 j) (CONST I32 i) (CONST I32 n) (MEMORY.COPY)  ~>
-    (CONST I32 $(j+n-1)) (CONST I32 $(i+n-1)) (LOAD I32 (8 _ U) 0 0) (STORE I32 8 0 0)
+    (CONST I32 $(j+n-1)) (CONST I32 $(i+n-1)) (LOAD I32 (8 _ U) $memop0) (STORE I32 8 $memop0)
     (CONST I32 j) (CONST I32 i) (CONST I32 $(n-1)) (MEMORY.COPY)
   -- otherwise
 
@@ -391,7 +396,7 @@ rule Step_read/memory.init-zero:
 
 rule Step_read/memory.init-succ:
   z; (CONST I32 j) (CONST I32 i) (CONST I32 n) (MEMORY.INIT x)  ~>
-    (CONST I32 j) (CONST I32 $data(z,x).DATA[i]) (STORE I32 8 0 0)
+    (CONST I32 j) (CONST I32 $data(z,x).DATA[i]) (STORE I32 8 $memop0)
     (CONST I32 $(j+1)) (CONST I32 $(i+1)) (CONST I32 $(n-1)) (MEMORY.INIT x)
   -- otherwise
 

--- a/spectec/spec/7-module.watsup
+++ b/spectec/spec/7-module.watsup
@@ -35,7 +35,8 @@ def $mems(externval externval'*) = $mems(externval'*)
 
 def $allocfunc(store, moduleinst, func) : (store, funcaddr)
 def $allocfunc(s, mm, func) = (s[.FUNC =.. fi], |s.FUNC|)
-  -- if fi = { MODULE mm, CODE func }
+  -- if fi = { TYPE moduleinst.TYPE[x], MODULE mm, CODE func }
+  -- if func = FUNC x local* expr
 
 def $allocfuncs(store, moduleinst, func*) : (store, funcaddr*)
 def $allocfuncs(s, mm, epsilon) = (s, epsilon)
@@ -79,19 +80,19 @@ def $allocelem(s, rt, ref*) = (s[.ELEM =.. ei], |s.ELEM|)
 
 def $allocelems(store, reftype*, (ref*)*) : (store, elemaddr*)
 def $allocelems(s, epsilon, epsilon) = (s, epsilon)
-def $allocelems(s, rt rt'*, ref* ref'**) = (s_2, ea ea'*)
+def $allocelems(s, rt rt'*, (ref*) (ref'*)*) = (s_2, ea ea'*)
   -- if (s_1, ea) = $allocelem(s, rt, ref*)
-  -- if (s_2, ea'*) = $allocelems(s_2, rt'*, ref'**)
+  -- if (s_2, ea'*) = $allocelems(s_2, rt'*, (ref'*)*)
 
 def $allocdata(store, byte*) : (store, dataaddr)
 def $allocdata(s, byte*) = (s[.DATA =.. di], |s.DATA|)
   -- if di = { DATA byte* }
 
-def $allocdatas(store, byte**) : (store, dataaddr*)
+def $allocdatas(store, (byte*)*) : (store, dataaddr*)
 def $allocdatas(s, epsilon) = (s, epsilon)
 def $allocdatas(s, byte* byte'**) = (s_2, da da'*)
   -- if (s_1, da) = $allocdata(s, byte*)
-  -- if (s_2, da'*) = $allocdatas(s_1, byte'**)
+  -- if (s_2, da'*) = $allocdatas(s_1, (byte'*)*)
 
 
 ;; Modules
@@ -107,6 +108,7 @@ def $allocmodule(store, module, externval*, val*, (ref*)*) : (store, moduleinst)
 def $allocmodule(s, module, externval*, val*, (ref*)*) = (s_6, mm)
   -- if module =
     MODULE
+      (TYPE ft)*
       import*
       func^n_func
       (GLOBAL globaltype expr_1)^n_global
@@ -128,6 +130,7 @@ def $allocmodule(s, module, externval*, val*, (ref*)*) = (s_6, mm)
   -- if da* = $(|s.DATA|+i_data)^(i_data<n_data)
   -- if xi* = $instexport(fa_ex* fa*, ga_ex* ga*, ta_ex* ta*, ma_ex* ma*, export)*
   -- if mm = {
+      TYPE ft,
       FUNC fa_ex* fa*,
       GLOBAL ga_ex* ga*,
       TABLE ta_ex* ta*,
@@ -167,8 +170,12 @@ def $rundata(DATA byte* (ACTIVE 0 instr*), i) =
 
 def $instantiate(store, module, externval*) : config
 def $instantiate(s, module, externval*) = s'; f; instr_elem* instr_data* (CALL x)?
-  -- if module = MODULE import* func* global* table* mem* elem* data* start? export*
+  -- if module = MODULE type* import* func* global* table* mem* elem* data* start? export*
+  -- if type* = (TYPE functype)*
+  -- if global* = (GLOBAL globaltype instr_1*)*
+  -- if elem* = (ELEM reftype (instr_2*)* elemmode)*
   -- if mm_init = {
+      TYPE functype*,
       FUNC $funcs(externval*),
       GLOBAL $globals(externval*),
       TABLE epsilon,
@@ -178,9 +185,7 @@ def $instantiate(s, module, externval*) = s'; f; instr_elem* instr_data* (CALL x
       EXPORT epsilon
     }
   -- if f_init = { LOCAL epsilon, MODULE mm_init }
-  -- if global* = (GLOBAL globaltype instr_1*)*
   -- (Step_read : s; f_init; instr_1* ~> val)*
-  -- if elem* = (ELEM reftype (instr_2*)* elemmode)*
   -- (Step_read : s; f_init; instr_2* ~> ref)**
   -- if (s', mm) = $allocmodule(s, module, externval*, val*, (ref*)*)
   -- if f = { LOCAL epsilon, MODULE mm }
@@ -207,5 +212,4 @@ def $invoke(s, fa, val^n) = s; f; val^n (CALL_ADDR fa)
       EXPORT epsilon
     }
   -- if f = { LOCAL epsilon, MODULE mm }
-  -- if $funcinst((s; f))[fa].CODE = FUNC ft local* e
-  -- if functype = t_1^n -> t_2^k
+  -- if $funcinst((s; f))[fa].TYPE = t_1^n -> t_2*

--- a/spectec/spec/A-binary.watsup
+++ b/spectec/spec/A-binary.watsup
@@ -1,0 +1,673 @@
+;;
+;; Auxiliaries
+;;
+
+;; Vectors
+
+grammar Bvec(grammar BX : X) : X* =
+  | n:Bu32 (X:BX)^n => X^n
+
+
+
+;;
+;; Values
+;;
+
+;; Numbers
+
+grammar Bbyte : byte = | b:0x00 | ... | b:0xFF => b
+
+grammar Bu(N) : nat hint(show Bu#N) =
+  | n:Bbyte                => n                       -- if $(n < 2^7 /\ n < 2^N)
+  | n:Bbyte m:Bu(($(N-7))) => $(2^7 * m + (n - 2^7))  -- if $(n >= 2^7 /\ N > 7)
+
+grammar Bs(N) : int hint(show Bs#N) =
+  | n:Bbyte                => n                       -- if $(n < 2^6 /\ n < 2^(N-1))
+  | n:Bbyte                => $(n - 2^7)              -- if $(2^6 <= n < 2^7 /\ n >= 2^7 - 2^(N-1))
+  | n:Bbyte i:Bu(($(N-7))) => $(2^7 * i + (n - 2^7))  -- if $(n >= 2^7 /\ N > 7)
+
+grammar Bi(N) : int hint(show Bi#N) =
+  | i:Bs(N)                => $invsigned(N, i)
+
+
+grammar Bf(N) : fN hint(show Bf#N) =
+  | b*:Bbyte^(N/8)  => $invfbytes(N, b*)
+
+
+grammar Bu32 : u32 = | n:Bu(32) => n
+grammar Bu64 : u64 = | n:Bu(64) => n
+grammar Bs33 : s33 = | i:Bs(33) => i
+
+grammar Bf32 : f32 = | p:Bf(32) => p
+grammar Bf64 : f64 = | p:Bf(64) => p
+
+
+;; Names
+
+def $concat_bytes(byte**) : byte*  hint(show $concat(%))
+def $concat_bytes(epsilon) = epsilon
+def $concat_bytes(b* b'**) = b* $concat_bytes(b'**)
+
+def $utf8(name) : byte*
+def $utf8(c) = b  -- if c < U+0080 /\ c = b
+def $utf8(c) = b_1 b_2  -- if U+0080 <= c < U+0800 /\ c = $(2^6*(b_1 - 0xC0) + (b_2 - 0x80))
+def $utf8(c) = b_1 b_2 b_3  -- if (U+0800 <= c < U+D800 \/ U+E000 <= c < U+10000) /\ c = $(2^12*(b_1 - 0xE0) + 2^6*(b_2 - 0x80) + (b_3 - 0x80))
+def $utf8(c) = b_1 b_2 b_3 b_4  -- if (U+10000 <= c < U+11000) /\ c = $(2^18*(b_1 - 0xF0) + 2^12*(b_2 - 0x80) + 2^6*(b_3 - 0x80) + (b_4 - 0x80))
+def $utf8(c*) = $concat_bytes($utf8(c)*)
+
+grammar Bname : name =
+  | b*:Bvec(Bbyte) => name  -- if $utf8(name) = b*
+
+
+;;
+;; Types
+;;
+
+;; Value types
+
+grammar Bnumtype : numtype =
+  | 0x7F => I32
+  | 0x7E => I64
+  | 0x7D => F32
+  | 0x7C => F64
+
+grammar Bvectype : vectype =
+  | 0x7B => V128
+
+grammar Breftype : reftype =
+  | 0x70 => FUNCREF
+  | 0x6F => EXTERNREF
+
+grammar Bvaltype : valtype =
+  | nt:Bnumtype => nt
+  | vt:Bvectype => vt
+  | rt:Breftype => rt
+
+
+grammar Bresulttype : resulttype =
+  | t*:Bvec(Bvaltype) => t*
+
+
+;; Type definitions
+
+grammar Bfunctype : functype =
+  | 0x60 t_1*:Bresulttype t_2*:Bresulttype => t_1* -> t_2*
+
+
+;; External types
+
+grammar Bmut : mut =
+  | 0x00 => MUT
+  | 0x01 => epsilon
+
+grammar Blimits : limits =
+  | 0x00 n:Bu32 => `[n .. $(2^32-1)]
+  | 0x01 n:Bu32 m:Bu32 => `[n .. m]
+
+grammar Bglobaltype : globaltype =
+  | t:Bvaltype mut:Bmut => mut t
+
+grammar Btabletype : tabletype =
+  | rt:Breftype lim:Blimits => lim rt
+
+grammar Bmemtype : memtype =
+  | lim:Blimits => lim I8
+
+
+grammar Bexterntype : externtype =
+  | 0x00 ft:Bfunctype => FUNC ft  ;; TODO: typeidx
+  | 0x01 tt:Btabletype => TABLE tt
+  | 0x02 mt:Bmemtype => MEM mt
+  | 0x03 gt:Bglobaltype => GLOBAL gt
+
+
+;;
+;; Instructions
+;;
+
+;; Block types
+
+grammar Bblocktype : blocktype =
+  | 0x40 => _RESULT epsilon
+  | t:Bvaltype => _RESULT t
+  | i:Bs33 => _IDX x  -- if i >= 0 /\ i = x
+
+
+;; Control instructions
+
+grammar Binstr/control : instr =
+  | 0x00 => UNREACHABLE
+  | 0x01 => NOP
+  | 0x02 bt:Bblocktype (in:Binstr)* 0x0B => BLOCK bt in*
+  | 0x03 bt:Bblocktype (in:Binstr)* 0x0B => LOOP bt in*
+  | 0x04 bt:Bblocktype (in:Binstr)* 0x0B => IF bt in* ELSE epsilon
+  | 0x04 bt:Bblocktype (in_1:Binstr)* 0x05 (in_2:Binstr)* 0x0B => IF bt in_1* ELSE in_2*
+  | 0x0C l:Blabelidx => BR l
+  | 0x0D l:Blabelidx => BR_IF l
+  | 0x0E l*:Bvec(Blabelidx) l_N:Blabelidx => BR_TABLE l* l_N
+  | 0x0F => RETURN
+  | 0x10 x:Bfuncidx => CALL x
+  | 0x11 y:Btypeidx x:Btableidx => CALL_INDIRECT x y
+  | ...
+
+
+;; Reference instructions
+
+grammar Binstr/reference : instr = ...
+  | 0xD0 rt:Breftype => REF.NULL rt
+  | 0xD1 => REF.IS_NULL
+  | 0xD2 x:Bfuncidx => REF.FUNC x
+  | ...
+
+
+;; Parametric instructions
+
+grammar Binstr/parametric : instr = ...
+  | 0x1A => DROP
+  | 0x1B => SELECT epsilon
+;;  | 0x1C t*:Bvec(Bvaltype) => SELECT (t*)    TODO
+  | ...
+
+
+;; Variable instructions
+
+grammar Binstr/variable : instr = ...
+  | 0x20 x:Blocalidx => LOCAL.GET x
+  | 0x21 x:Blocalidx => LOCAL.SET x
+  | 0x22 x:Blocalidx => LOCAL.TEE x
+  | 0x23 x:Bglobalidx => GLOBAL.GET x
+  | 0x24 x:Bglobalidx => GLOBAL.SET x
+  | ...
+
+
+;; Table instructions
+
+grammar Binstr/table : instr = ...
+  | 0x25 x:Btableidx => TABLE.GET x
+  | 0x26 x:Btableidx => TABLE.SET x
+  | 0xFC 12:Bu32 y:Belemidx x:Btableidx => TABLE.INIT x y
+  | 0xFC 13:Bu32 x:Belemidx => ELEM.DROP x
+  | 0xFC 14:Bu32 x_1:Btableidx x_2:Btableidx => TABLE.COPY x_1 x_2
+  | 0xFC 15:Bu32 x:Btableidx => TABLE.GROW x
+  | 0xFC 16:Bu32 x:Btableidx => TABLE.SIZE x
+  | 0xFC 17:Bu32 x:Btableidx => TABLE.FILL x
+  | ...
+
+
+;; Memory instructions
+
+grammar Bmemop : memop =
+  | n:Bu32 m:Bu32 => {ALIGN n, OFFSET m}
+
+grammar Binstr/memory : instr = ...
+  | 0x28 mo:Bmemop => LOAD I32 mo
+  | 0x29 mo:Bmemop => LOAD I64 mo
+  | 0x2A mo:Bmemop => LOAD F32 mo
+  | 0x2B mo:Bmemop => LOAD F64 mo
+  | 0x2C mo:Bmemop => LOAD I32 (8 _ S) mo
+  | 0x2D mo:Bmemop => LOAD I32 (8 _ U) mo
+  | 0x2E mo:Bmemop => LOAD I32 (16 _ S) mo
+  | 0x2F mo:Bmemop => LOAD I32 (16 _ U) mo
+  | 0x30 mo:Bmemop => LOAD I64 (8 _ S) mo
+  | 0x31 mo:Bmemop => LOAD I64 (8 _ U) mo
+  | 0x32 mo:Bmemop => LOAD I64 (16 _ S) mo
+  | 0x33 mo:Bmemop => LOAD I64 (16 _ U) mo
+  | 0x34 mo:Bmemop => LOAD I64 (32 _ S) mo
+  | 0x35 mo:Bmemop => LOAD I64 (32 _ U) mo
+  | 0x36 mo:Bmemop => STORE I32 mo
+  | 0x37 mo:Bmemop => STORE I64 mo
+  | 0x38 mo:Bmemop => STORE F32 mo
+  | 0x39 mo:Bmemop => STORE F64 mo
+  | 0x3A mo:Bmemop => STORE I32 8 mo
+  | 0x3B mo:Bmemop => STORE I32 16 mo
+  | 0x3C mo:Bmemop => STORE I64 8 mo
+  | 0x3D mo:Bmemop => STORE I64 16 mo
+  | 0x3E mo:Bmemop => STORE I64 32 mo
+  | 0x3F 0x00 => MEMORY.SIZE
+  | 0x40 0x00 => MEMORY.GROW
+  | 0xFC 8:Bu32 x:Bdataidx 0x00 => MEMORY.INIT x
+  | 0xFC 9:Bu32 x:Bdataidx => DATA.DROP x
+  | 0xFC 10:Bu32 0x00 0x00 => MEMORY.COPY
+  | 0xFC 11:Bu32 0x00 => MEMORY.FILL
+  | ...
+
+
+
+;; Numeric instructions
+
+grammar Binstr/numeric-const : instr = ...
+  | 0x41 n:Bu32 => CONST I32 n
+  | 0x42 n:Bu64 => CONST I64 n
+;;  | 0x43 p:Bf32 => CONST F32 p    ;; TODO
+;;  | 0x44 p:Bf64 => CONST F64 p    ;; TODO
+  | ...
+
+grammar Binstr/numeric-test-i32 : instr = ...
+  | 0x45 => TESTOP I32 (_I EQZ)
+  | ...
+
+grammar Binstr/numeric-rel-i32 : instr = ...
+  | 0x46 => RELOP I32 (_I EQ)
+  | 0x47 => RELOP I32 (_I NE)
+  | 0x48 => RELOP I32 (_I (LT S))
+  | 0x49 => RELOP I32 (_I (LT U))
+  | 0x4A => RELOP I32 (_I (GT S))
+  | 0x4B => RELOP I32 (_I (GT U))
+  | 0x4C => RELOP I32 (_I (LE S))
+  | 0x4D => RELOP I32 (_I (LE U))
+  | 0x4E => RELOP I32 (_I (GE S))
+  | 0x4F => RELOP I32 (_I (GE U))
+  | ...
+
+grammar Binstr/numeric-test-i64 : instr = ...
+  | 0x50 => TESTOP I64 (_I EQZ)
+  | ...
+
+grammar Binstr/numeric-rel-i64 : instr = ...
+  | 0x51 => RELOP I64 (_I EQ)
+  | 0x52 => RELOP I64 (_I NE)
+  | 0x53 => RELOP I64 (_I (LT S))
+  | 0x54 => RELOP I64 (_I (LT U))
+  | 0x55 => RELOP I64 (_I (GT S))
+  | 0x56 => RELOP I64 (_I (GT U))
+  | 0x57 => RELOP I64 (_I (LE S))
+  | 0x58 => RELOP I64 (_I (LE U))
+  | 0x59 => RELOP I64 (_I (GE S))
+  | 0x5A => RELOP I64 (_I (GE U))
+  | ...
+
+grammar Binstr/numeric-rel-f32 : instr = ...
+  | 0x5B => RELOP F32 (_F EQ)
+  | 0x5C => RELOP F32 (_F NE)
+  | 0x5D => RELOP F32 (_F LT)
+  | 0x5E => RELOP F32 (_F GT)
+  | 0x5F => RELOP F32 (_F LE)
+  | 0x60 => RELOP F32 (_F GE)
+  | ...
+
+grammar Binstr/numeric-rel-f64 : instr = ...
+  | 0x61 => RELOP F64 (_F EQ)
+  | 0x62 => RELOP F64 (_F NE)
+  | 0x63 => RELOP F64 (_F LT)
+  | 0x64 => RELOP F64 (_F GT)
+  | 0x65 => RELOP F64 (_F LE)
+  | 0x66 => RELOP F64 (_F GE)
+  | ...
+
+grammar Binstr/numeric-un-i32 : instr = ...
+  | 0x67 => UNOP I32 (_I CLZ)
+  | 0x68 => UNOP I32 (_I CTZ)
+  | 0x69 => UNOP I32 (_I POPCNT)
+  | ...
+
+grammar Binstr/numeric-bin-i32 : instr = ...
+  | 0x6A => BINOP I32 (_I ADD)
+  | 0x6B => BINOP I32 (_I SUB)
+  | 0x6C => BINOP I32 (_I MUL)
+  | 0x6D => BINOP I32 (_I (DIV S))
+  | 0x6E => BINOP I32 (_I (DIV U))
+  | 0x6F => BINOP I32 (_I (REM S))
+  | 0x70 => BINOP I32 (_I (REM U))
+  | 0x71 => BINOP I32 (_I AND)
+  | 0x72 => BINOP I32 (_I OR)
+  | 0x73 => BINOP I32 (_I XOR)
+  | 0x74 => BINOP I32 (_I SHL)
+  | 0x75 => BINOP I32 (_I (SHR S))
+  | 0x76 => BINOP I32 (_I (SHR U))
+  | 0x77 => BINOP I32 (_I ROTL)
+  | 0x78 => BINOP I32 (_I ROTR)
+  | ...
+
+grammar Binstr/numeric-un-i64 : instr = ...
+  | 0x79 => UNOP I64 (_I CLZ)
+  | 0x7A => UNOP I64 (_I CTZ)
+  | 0x7B => UNOP I64 (_I POPCNT)
+  | ...
+
+grammar Binstr/numeric-bin-i64 : instr = ...
+  | 0x7C => BINOP I64 (_I ADD)
+  | 0x7D => BINOP I64 (_I SUB)
+  | 0x7E => BINOP I64 (_I MUL)
+  | 0x7F => BINOP I64 (_I (DIV S))
+  | 0x80 => BINOP I64 (_I (DIV U))
+  | 0x81 => BINOP I64 (_I (REM S))
+  | 0x82 => BINOP I64 (_I (REM U))
+  | 0x83 => BINOP I64 (_I AND)
+  | 0x84 => BINOP I64 (_I OR)
+  | 0x85 => BINOP I64 (_I XOR)
+  | 0x86 => BINOP I64 (_I SHL)
+  | 0x87 => BINOP I64 (_I (SHR S))
+  | 0x88 => BINOP I64 (_I (SHR U))
+  | 0x89 => BINOP I64 (_I ROTL)
+  | 0x8A => BINOP I64 (_I ROTR)
+  | ...
+
+grammar Binstr/numeric-un-f32 : instr = ...
+  | 0x8B => UNOP F32 (_F ABS)
+  | 0x8C => UNOP F32 (_F NEG)
+  | 0x8D => UNOP F32 (_F CEIL)
+  | 0x8E => UNOP F32 (_F FLOOR)
+  | 0x8F => UNOP F32 (_F TRUNC)
+  | 0x90 => UNOP F32 (_F NEAREST)
+  | 0x91 => UNOP F32 (_F SQRT)
+  | ...
+
+grammar Binstr/numeric-bin-f32 : instr = ...
+  | 0x92 => BINOP F32 (_F ADD)
+  | 0x93 => BINOP F32 (_F SUB)
+  | 0x94 => BINOP F32 (_F MUL)
+  | 0x95 => BINOP F32 (_F DIV)
+  | 0x96 => BINOP F32 (_F MIN)
+  | 0x97 => BINOP F32 (_F MAX)
+  | 0x98 => BINOP F32 (_F COPYSIGN)
+  | ...
+
+grammar Binstr/numeric-un-f64 : instr = ...
+  | 0x99 => UNOP F64 (_F ABS)
+  | 0x9A => UNOP F64 (_F NEG)
+  | 0x9B => UNOP F64 (_F CEIL)
+  | 0x9C => UNOP F64 (_F FLOOR)
+  | 0x9D => UNOP F64 (_F TRUNC)
+  | 0x9E => UNOP F64 (_F NEAREST)
+  | 0x9F => UNOP F64 (_F SQRT)
+  | ...
+
+grammar Binstr/numeric-bin-f64 : instr = ...
+  | 0xA0 => BINOP F64 (_F ADD)
+  | 0xA1 => BINOP F64 (_F SUB)
+  | 0xA2 => BINOP F64 (_F MUL)
+  | 0xA3 => BINOP F64 (_F DIV)
+  | 0xA4 => BINOP F64 (_F MIN)
+  | 0xA5 => BINOP F64 (_F MAX)
+  | 0xA6 => BINOP F64 (_F COPYSIGN)
+  | ...
+
+
+grammar Binstr/numeric-cvt : instr = ...
+  | 0xA7 => CVTOP I32 CONVERT I64
+  | 0xA8 => CVTOP I32 CONVERT F32 S
+  | 0xA9 => CVTOP I32 CONVERT F32 U
+  | 0xAA => CVTOP I32 CONVERT F64 S
+  | 0xAB => CVTOP I32 CONVERT F64 U
+  | 0xAC => CVTOP I64 CONVERT I32 S
+  | 0xAD => CVTOP I64 CONVERT I32 U
+  | 0xAE => CVTOP I64 CONVERT F32 S
+  | 0xAF => CVTOP I64 CONVERT F32 U
+  | 0xB0 => CVTOP I64 CONVERT F64 S
+  | 0xB1 => CVTOP I64 CONVERT F64 U
+  | 0xB2 => CVTOP F32 CONVERT I32 S
+  | 0xB3 => CVTOP F32 CONVERT I32 U
+  | 0xB4 => CVTOP F32 CONVERT I64 S
+  | 0xB5 => CVTOP F32 CONVERT I64 U
+  | 0xB6 => CVTOP F32 CONVERT F64
+  | 0xB7 => CVTOP F64 CONVERT I32 S
+  | 0xB8 => CVTOP F64 CONVERT I32 U
+  | 0xB9 => CVTOP F64 CONVERT I64 S
+  | 0xBA => CVTOP F64 CONVERT I64 U
+  | 0xBB => CVTOP F64 CONVERT F32
+  | 0xBC => CVTOP I32 REINTERPRET F32
+  | 0xBD => CVTOP I64 REINTERPRET F64
+  | 0xBE => CVTOP F32 REINTERPRET I32
+  | 0xBF => CVTOP F64 REINTERPRET I64
+  | 0xFC 0:Bu32 => CVTOP I32 CONVERT_SAT F32 S
+  | 0xFC 1:Bu32 => CVTOP I32 CONVERT_SAT F32 U
+  | 0xFC 2:Bu32 => CVTOP I32 CONVERT_SAT F64 S
+  | 0xFC 3:Bu32 => CVTOP I32 CONVERT_SAT F64 U
+  | 0xFC 4:Bu32 => CVTOP I64 CONVERT_SAT F32 S
+  | 0xFC 5:Bu32 => CVTOP I64 CONVERT_SAT F32 U
+  | 0xFC 6:Bu32 => CVTOP I64 CONVERT_SAT F64 S
+  | 0xFC 7:Bu32 => CVTOP I64 CONVERT_SAT F64 U
+  | ...
+
+grammar Binstr/numeric-extend : instr = ...
+  | 0xC0 => EXTEND I32 8
+  | 0xC1 => EXTEND I32 16
+  | 0xC2 => EXTEND I64 8
+  | 0xC3 => EXTEND I64 16
+  | 0xC4 => EXTEND I64 32
+  | ...
+
+
+;; Expressions
+
+grammar Bexpr : expr =
+  | (in:Binstr)* 0x0B => in*
+
+
+
+;;
+;; Modules
+;;
+
+;; Indices
+
+grammar Btypeidx : typeidx = | x:Bu32 => x
+grammar Bfuncidx : funcidx = | x:Bu32 => x
+grammar Bglobalidx : globalidx = | x:Bu32 => x
+grammar Btableidx : tableidx = | x:Bu32 => x
+grammar Bmemidx : memidx = | x:Bu32 => x
+grammar Belemidx : elemidx = | x:Bu32 => x
+grammar Bdataidx : dataidx = | x:Bu32 => x
+grammar Blocalidx : localidx = | x:Bu32 => x
+grammar Blabelidx : labelidx = | x:Bu32 => x
+
+grammar Bexternidx : externidx =
+  | 0x00 x:Bfuncidx => FUNC x
+  | 0x01 x:Btableidx => TABLE x
+  | 0x02 x:Bmemidx => MEM x
+  | 0x03 x:Bglobalidx => GLOBAL x
+
+
+;; Sections
+
+var sz : nat
+
+grammar Bsection_(N, grammar B : S*) : S*  hint(desc "section") =
+  | N:Bbyte sz:Bu32 S*:B => S*  -- if sz = ||B||
+  | epsilon => epsilon
+
+
+;; Custom sections
+
+grammar Bcustomsec : () hint(desc "custom section") =
+  | Bsection_(0, Bcustom) => ()
+
+grammar Bcustom : ()* hint(desc "custom data") =
+  | Bname Bbyte* => ()
+
+
+;; Type section
+
+grammar Btypesec : type* hint(desc "type section") =
+  | ty*:Bsection_(1, Bvec(Btype)) => ty*
+
+grammar Btype : type =
+  | ft:Bfunctype => TYPE ft
+
+
+;; Import section
+
+grammar Bimportsec : import* hint(desc "import section") =
+  | im*:Bsection_(2, Bvec(Bimport)) => im*
+
+grammar Bimport : import =
+  | nm_1:Bname nm_2:Bname xt:Bexterntype => IMPORT nm_1 nm_2 xt
+
+
+;; Function section
+
+grammar Bfuncsec : typeidx* hint(desc "function section") =
+  | x*:Bsection_(3, Bvec(Btypeidx)) => x*
+
+
+;; Table section
+
+grammar Btablesec : table* hint(desc "table section") =
+  | tab*:Bsection_(4, Bvec(Btable)) => tab*
+
+grammar Btable : table =
+  | tt:Btabletype => TABLE tt
+
+
+;; Memory section
+
+grammar Bmemsec : mem* hint(desc "memory section") =
+  | mem*:Bsection_(5, Bvec(Bmem)) => mem*
+
+grammar Bmem : mem =
+  | mt:Bmemtype => MEMORY mt
+
+
+;; Global section
+
+grammar Bglobalsec : global* hint(desc "global section") =
+  | glob*:Bsection_(6, Bvec(Bglobal)) => glob*
+
+grammar Bglobal : global =
+  | gt:Bglobaltype e:Bexpr => GLOBAL gt e
+
+
+;; Export section
+
+grammar Bexportsec : export* hint(desc "export section") =
+  | ex*:Bsection_(7, Bvec(Bexport)) => ex*
+
+grammar Bexport : export =
+  | nm:Bname xx:Bexternidx => EXPORT nm xx
+
+
+;; Start section
+
+grammar Bstartsec : start* hint(desc "start section") =
+  | st*:Bsection_(8, Bstart) => st*
+
+grammar Bstart : start* =
+  | x:Bfuncidx => (START x)
+
+
+;; Element section
+
+grammar Belemsec : elem* hint(desc "element section") =
+  | elem*:Bsection_(9, Bvec(Belem)) => elem*
+
+grammar Belem : elem =
+  | 0:Bu32 e_o:Bexpr y*:Bvec(Bfuncidx) =>
+      ELEM FUNCREF (REF.FUNC y)* (ACTIVE 0 e_o)
+  | 1:Bu32 rt:Belemkind y*:Bvec(Bfuncidx) =>
+      ELEM rt (REF.FUNC y)* PASSIVE
+  | 2:Bu32 x:Btableidx expr:Bexpr rt:Belemkind y*:Bvec(Bfuncidx) =>
+      ELEM rt (REF.FUNC y)* (ACTIVE x expr)
+  | 3:Bu32 rt:Belemkind y*:Bvec(Bfuncidx) =>
+      ELEM rt (REF.FUNC y)* DECLARE
+  | 4:Bu32 e_o:Bexpr e*:Bvec(Bexpr) =>
+      ELEM FUNCREF e* (ACTIVE 0 e_o)
+  | 5:Bu32 rt:Breftype e*:Bvec(Bexpr) =>
+      ELEM rt e* PASSIVE
+  | 6:Bu32 x:Btableidx expr:Bexpr e*:Bvec(Bexpr) =>
+      ELEM FUNCREF e* (ACTIVE x expr)
+  | 7:Bu32 rt:Breftype e*:Bvec(Bexpr) =>
+      ELEM rt e* DECLARE
+
+grammar Belemkind : reftype hint(desc "element kind") =
+  | 0x00 => FUNCREF
+
+
+;; Code section
+
+def $concat_locals(local**) : local*  hint(show $concat(%))
+def $concat_locals(epsilon) = epsilon
+def $concat_locals(loc* loc'**) = loc* $concat_locals(loc'**)
+
+
+syntax code = (local*, expr)
+
+grammar Bcodesec : code* hint(desc "code section") =
+  | code*:Bsection_(10, Bvec(Bcode)) => code*
+
+grammar Bcode : code =
+  | sz:Bu32 code:Bfunc => code  -- if sz = ||Bfunc||
+
+grammar Bfunc : code =
+  | local**:Bvec(Blocals) expr:Bexpr => ($concat_locals(local**), expr)
+
+grammar Blocals : local* hint(desc "local") =
+  | n:Bu32 t:Bvaltype => (LOCAL t)^n
+
+
+;; Data section
+
+grammar Bdatasec : data* hint(desc "data section") =
+  | data*:Bsection_(11, Bvec(Bdata)) => data*
+
+grammar Bdata : data =
+  | 0:Bu32 e:Bexpr b*:Bvec(Bbyte) => DATA b* (ACTIVE 0 e)
+  | 1:Bu32 b*:Bvec(Bbyte) => DATA b* PASSIVE
+  | 2:Bu32 x:Bmemidx e:Bexpr b*:Bvec(Bbyte) => DATA b* (ACTIVE x e)
+
+
+;; Data count section
+
+grammar Bdatacntsec : u32* hint(desc "data count section") =
+  | n*:Bsection_(12, Bdatacnt) => n*
+
+grammar Bdatacnt : u32* hint(desc "data count") =
+  | n:Bu32 => n
+
+
+;; Modules
+
+grammar Bmodule : module =
+  | 0x00 0x61 0x73 0x6D 1:Bu32
+    Bcustomsec*
+
+
+    type*:Btypesec
+    Bcustomsec*
+
+
+    import*:Bimportsec
+    Bcustomsec*
+
+
+    typeidx^n:Bfuncsec
+    Bcustomsec*
+
+
+    table*:Btablesec
+    Bcustomsec*
+
+
+    mem*:Bmemsec
+    Bcustomsec*
+
+
+    global*:Bglobalsec
+    Bcustomsec*
+
+
+    export*:Bexportsec
+    Bcustomsec*
+
+
+    start*:Bstartsec
+    Bcustomsec*
+
+
+    elem*:Belemsec
+    Bcustomsec*
+
+
+    m'*:Bdatacntsec
+    Bcustomsec*
+
+
+    (local*, expr)^n:Bcodesec
+    Bcustomsec*
+
+
+    data^m:Bdatasec
+    Bcustomsec* =>
+      MODULE type* import* func^n global* table* mem* elem* data^m start* export*
+    -- if m'* = epsilon \/ $free_dataidx_funcs(func^n) = epsilon
+    -- if m = $sum(m'*)
+    -- if (func = FUNC typeidx local* expr)*

--- a/spectec/src/el/ast.ml
+++ b/spectec/src/el/ast.ml
@@ -59,11 +59,17 @@ type iter =
 
 (* Types *)
 
+and numtyp =
+  | NatT                         (* `nat` *)
+  | IntT                         (* `int` *)
+  | RatT                         (* `rat` *)
+  | RealT                        (* `real` *)
+
 and typ = typ' phrase
 and typ' =
   | VarT of id                   (* varid *)
   | BoolT                        (* `bool` *)
-  | NatT                         (* `nat` *)
+  | NumT of numtyp               (* numtyp *)
   | TextT                        (* `text` *)
   | ParenT of typ                (* `(` typ `)` *)
   | TupT of typ list             (* `(` list2(typ, `,`) `)` *)
@@ -131,6 +137,7 @@ and exp' =
   | CommaE of exp * exp          (* exp `,` exp *)
   | CompE of exp * exp           (* exp `++` exp *)
   | LenE of exp                  (* `|` exp `|` *)
+  | SizeE of id                  (* `||` exp `||` *)
   | ParenE of exp * bool         (* `(` exp `)` *)
   | TupE of exp list             (* `(` list2(exp, `,`) `)` *)
   | InfixE of exp * atom * exp   (* exp atom exp *)
@@ -150,17 +157,49 @@ and path' =
   | DotP of path * atom          (* path `.` atom *)
 
 
+(* Grammars *)
+
+and sym = sym' phrase
+and sym' =
+  | VarG of id * sym list                    (* gramid (`(` sym,* `)`)? *)
+  | NatG of int                              (* nat *)
+  | HexG of int                              (* 0xhex *)
+  | CharG of int                             (* U+hex *)
+  | TextG of string                          (* `"`text`"` *)
+  | EpsG                                     (* `epsilon` *)
+  | SeqG of sym nl_list                      (* sym sym *)
+  | AltG of sym nl_list                      (* sym `|` sym *)
+  | RangeG of sym * sym                      (* sym `|` `...` `|` sym *)
+  | ParenG of sym                            (* `(` sym `)` *)
+  | TupG of sym list                         (* `(` sym ',' ... ',' sym `)` *)
+  | IterG of sym * iter                      (* sym iter *)
+  | ArithG of exp                            (* `$(` exp `)` *)
+  | AttrG of sym * exp                       (* exp `:` sym *)
+
+and prod = prod' phrase
+and prod' = sym * exp * premise nl_list      (* `|` sym `=>` exp (`--` premise)* *)
+
+and gram = gram' phrase
+and gram' = dots * prod nl_list * dots       (* `|` list(`...`|prod, `|`) *)
+
+
 (* Definitions *)
+
+and param = param' phrase
+and param' =
+  | VarP of id                                (* varid *)
+  | GramP of id * id * iter list              (* `grammar` gramid `:` varid iter* *)
 
 and def = def' phrase
 and def' =
-  | SynD of id * id * typ * hint list        (* `syntax` synid hint* `=` typ *)
-  | RelD of id * typ * hint list             (* `relation` relid `:` typ hint* *)
-  | RuleD of id * id * exp * premise nl_list (* `rule` relid ruleid? `:` exp (`--` premise)* *)
-  | VarD of id * typ * hint list             (* `var` varid `:` typ *)
-  | DecD of id * exp * typ * hint list       (* `def` `$` defid exp? `:` typ hint* *)
-  | DefD of id * exp * exp * premise nl_list (* `def` `$` defid exp? `=` exp (`--` premise)* *)
-  | SepD                                     (* separator *)
+  | SynD of id * id * typ * hint list         (* `syntax` synid hint* `=` typ *)
+  | GramD of id * id * param list * typ * gram * hint list (* `grammar` gramid hint* `:` type `=` gram *)
+  | RelD of id * typ * hint list              (* `relation` relid `:` typ hint* *)
+  | RuleD of id * id * exp * premise nl_list  (* `rule` relid ruleid? `:` exp (`--` premise)* *)
+  | VarD of id * typ * hint list              (* `var` varid `:` typ *)
+  | DecD of id * exp * typ * hint list        (* `def` `$` defid exp? `:` typ hint* *)
+  | DefD of id * exp * exp * premise nl_list  (* `def` `$` defid exp? `=` exp (`--` premise)* *)
+  | SepD                                      (* separator *)
   | HintD of hintdef
 
 and premise = premise' phrase
@@ -174,6 +213,7 @@ and hintdef = hintdef' phrase
 and hintdef' =
   | AtomH of id * hint list
   | SynH of id * id * hint list
+  | GramH of id * id * hint list
   | RelH of id * hint list
   | VarH of id * hint list
   | DecH of id * hint list

--- a/spectec/src/el/eq.ml
+++ b/spectec/src/el/eq.ml
@@ -119,3 +119,13 @@ and eq_prem prem1 prem2 =
   | IterPr (prem11, iter1), IterPr (prem21, iter2) ->
     eq_prem prem11 prem21 && eq_iter iter1 iter2
   | _, _ -> prem1.it = prem2.it
+
+
+(* Grammars *)
+
+let eq_param p1 p2 =
+  match p1.it, p2.it with
+  | VarP id1, VarP id2 -> id1.it = id2.it
+  | GramP (id11, id12, iters1), GramP (id21, id22, iters2) ->
+    id11.it = id21.it && id12.it = id22.it && eq_list eq_iter iters1 iters2
+  | _, _ -> false

--- a/spectec/src/el/eq.mli
+++ b/spectec/src/el/eq.mli
@@ -3,5 +3,6 @@ open Ast
 val eq_iter : iter -> iter -> bool
 val eq_exp : exp -> exp -> bool
 val eq_typ : typ -> typ -> bool
+val eq_param : param -> param -> bool
 
 val eq_list : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool

--- a/spectec/src/el/free.mli
+++ b/spectec/src/el/free.mli
@@ -2,7 +2,7 @@ open Ast
 
 module Set : Set.S with type elt = string
 
-type sets = {synid : Set.t; relid : Set.t; varid : Set.t; defid : Set.t}
+type sets = {synid : Set.t; gramid : Set.t; relid : Set.t; varid : Set.t; defid : Set.t}
 
 val free_list : ('a -> sets) -> 'a list -> sets
 val free_nl_list : ('a -> sets) -> 'a nl_list -> sets

--- a/spectec/src/exe-watsup/main.ml
+++ b/spectec/src/exe-watsup/main.ml
@@ -41,6 +41,7 @@ let srcs = ref []    (* src file arguments *)
 let dsts = ref []    (* destination file arguments *)
 let odst = ref ""    (* generation file argument *)
 
+let print_el = ref false
 let print_elab_il = ref false
 let print_final_il = ref false
 let print_all_il = ref false
@@ -106,9 +107,10 @@ let argspec = Arg.align
     " Generate Latex for Sphinx";
   "--prose", Arg.Unit (fun () -> target := Prose), " Generate prose";
 
-  "--print-il", Arg.Set print_elab_il, " Print il (after elaboration)";
-  "--print-final-il", Arg.Set print_final_il, " Print final il";
-  "--print-all-il", Arg.Set print_all_il, " Print il after each step";
+  "--print-el", Arg.Set print_el, " Print EL";
+  "--print-il", Arg.Set print_elab_il, " Print IL (after elaboration)";
+  "--print-final-il", Arg.Set print_final_il, " Print final IL";
+  "--print-all-il", Arg.Set print_all_il, " Print IL after each step";
 ] @ List.map pass_argspec all_passes @ [
   "--all-passes", Arg.Unit (fun () -> List.iter enable_pass all_passes)," Run all passes";
 
@@ -128,6 +130,8 @@ let () =
     Arg.parse argspec add_arg usage;
     log "Parsing...";
     let el = List.concat_map Frontend.Parse.parse_file !srcs in
+    if !print_el then
+      Printf.printf "%s\n%!" (El.Print.string_of_script el);
     log "Elaboration...";
     let il = Frontend.Elab.elab el in
     if !print_elab_il || !print_all_il then

--- a/spectec/src/frontend/elab.ml
+++ b/spectec/src/frontend/elab.ml
@@ -11,6 +11,7 @@ module Map = Map.Make(String)
 
 let filter_nl xs = List.filter_map (function Nl -> None | Elem x -> Some x) xs
 let map_nl_list f xs = List.map f (filter_nl xs)
+let iter_nl_list f xs = List.iter f (filter_nl xs)
 
 
 (* Errors *)
@@ -77,18 +78,38 @@ let cat_exp' e1' e2' =
   | _ -> Il.CatE (e1', e2')
 
 
+let rec exp_of_sym sym =
+  let e =
+    match sym.it with
+    | VarG (id, []) -> VarE id
+    | NatG n -> NatE n
+    | HexG n -> HexE n
+    | CharG n -> CharE n
+    | TextG t -> TextE t
+    | EpsG -> EpsE
+    | SeqG gs -> SeqE (map_nl_list exp_of_sym gs)
+    | ParenG g -> ParenE (exp_of_sym g, false)
+    | TupG gs -> TupE (List.map exp_of_sym gs)
+    | IterG (g, iter) -> IterE (exp_of_sym g, iter)
+    | ArithG e -> e.it
+    | VarG _ | AltG _ | RangeG _ | AttrG _ ->
+      Source.error sym.at "syntax" "malformed expression"
+  in e $ sym.at
+
 
 (* Environment *)
 
 type fwd_typ = Bad | Ok
 type var_typ = typ
 type syn_typ = (fwd_typ, typ * Il.deftyp) Either.t
+type gram_typ = param list * typ * gram option
 type rel_typ = typ * Il.rule list
 type def_typ = typ * typ * Il.clause list
 
 type env =
   { mutable vars : var_typ Map.t;
     mutable typs : syn_typ Map.t;
+    mutable syms : gram_typ Map.t;
     mutable rels : rel_typ Map.t;
     mutable defs : def_typ Map.t;
   }
@@ -96,9 +117,13 @@ type env =
 let new_env () =
   { vars = Map.empty
       |> Map.add "bool" (BoolT $ no_region)
-      |> Map.add "nat" (NatT $ no_region)
+      |> Map.add "nat" (NumT NatT $ no_region)
+      |> Map.add "int" (NumT IntT $ no_region)
+      |> Map.add "rat" (NumT RatT $ no_region)
+      |> Map.add "real" (NumT RealT $ no_region)
       |> Map.add "text" (TextT $ no_region);
     typs = Map.empty;
+    syms = Map.empty;
     rels = Map.empty;
     defs = Map.empty;
   }
@@ -145,7 +170,8 @@ let as_defined_typid' env id at : typ' * [`Alias | `NoAlias] =
   match find "syntax type" env.typs id with
   | Either.Right (t, {it = Il.AliasT _t'; _}) -> t.it, `Alias
   | Either.Right (t, _deftyp') -> t.it, `NoAlias
-  | Either.Left _ ->
+  | Either.Left Ok -> VarT id, `NoAlias
+  | Either.Left Bad ->
     error_id (id.it $ at) "invalid forward use of syntax type"
 
 let rec expand' env = function
@@ -252,8 +278,14 @@ let rec equiv_typ env t1 t2 =
   | TupT ts1, TupT ts2 -> equiv_list (equiv_typ env) ts1 ts2
   | IterT (t11, iter1), IterT (t21, iter2) ->
     equiv_typ env t11 t21 && Eq.eq_iter iter1 iter2
-  | RangeT _, NatT | NatT, RangeT _ -> true
+  | RangeT _, NumT NatT | NumT NatT, RangeT _ -> true
   | t1', t2' -> Eq.eq_typ (t1' $ t1.at) (t2' $ t2.at)
+
+let sub_typ env t1 t2 =
+  equiv_typ env t1 t2 ||
+  match expand env t1, expand env t2 with
+  | NumT t1', NumT t2' -> t1' < t2'
+  | _ -> false
 
 
 (* Hints *)
@@ -300,29 +332,74 @@ let elab_brack = function
   | Brack -> Il.LBrack, Il.RBrack
   | Brace -> Il.LBrace, Il.RBrace
 
-let elab_unop = function
-  | NotOp -> Il.NotOp
-  | PlusOp -> Il.PlusOp
-  | MinusOp -> Il.MinusOp
+let numtyps = [NatT; IntT; RatT; RealT]
 
-let elab_binop = function
-  | AndOp -> Il.AndOp
-  | OrOp -> Il.OrOp
-  | ImplOp -> Il.ImplOp
-  | EquivOp -> Il.EquivOp
-  | AddOp -> Il.AddOp
-  | SubOp -> Il.SubOp
-  | MulOp -> Il.MulOp
-  | DivOp -> Il.DivOp
-  | ExpOp -> Il.ExpOp
+let elab_numtyp t : Il.numtyp =
+  match t with
+  | NatT -> Il.NatT
+  | IntT -> Il.IntT
+  | RatT -> Il.RatT
+  | RealT -> Il.RealT
 
-let elab_cmpop = function
-  | EqOp -> Il.EqOp
-  | NeOp -> Il.NeOp
-  | LtOp -> Il.LtOp
-  | GtOp -> Il.GtOp
-  | LeOp -> Il.LeOp
-  | GeOp -> Il.GeOp
+let infer_numop fop' ts =
+  List.map (fun t -> fop' (elab_numtyp t), NumT t) ts
+
+let infer_unop = function
+  | NotOp -> [Il.NotOp, BoolT]
+  | PlusOp -> infer_numop (fun t -> Il.PlusOp t) (List.tl numtyps)
+  | MinusOp -> infer_numop (fun t -> Il.MinusOp t) (List.tl numtyps)
+
+let infer_binop = function
+  | AndOp -> [Il.AndOp, BoolT]
+  | OrOp -> [Il.OrOp, BoolT]
+  | ImplOp -> [Il.ImplOp, BoolT]
+  | EquivOp -> [Il.EquivOp, BoolT]
+  | AddOp -> infer_numop (fun t -> Il.AddOp t) numtyps
+  | SubOp -> infer_numop (fun t -> Il.SubOp t) numtyps
+  | MulOp -> infer_numop (fun t -> Il.MulOp t) numtyps
+  | DivOp -> infer_numop (fun t -> Il.DivOp t) numtyps
+  | ExpOp -> infer_numop (fun t -> Il.ExpOp t) numtyps
+
+let infer_cmpop = function
+  | EqOp -> `Poly Il.EqOp
+  | NeOp -> `Poly Il.NeOp
+  | LtOp -> `Over (infer_numop (fun t -> Il.LtOp t) numtyps)
+  | GtOp -> `Over (infer_numop (fun t -> Il.GtOp t) numtyps)
+  | LeOp -> `Over (infer_numop (fun t -> Il.LeOp t) numtyps)
+  | GeOp -> `Over (infer_numop (fun t -> Il.GeOp t) numtyps)
+
+let elab_unop env op t1 at : Il.unop * typ =
+  let ops = infer_unop op in
+  match List.find_opt (fun (_, t) -> sub_typ env t1 (t $ at)) ops with
+  | Some (op', t) -> op', t $ at
+  | None ->
+    error at ("operator is not defined for type `" ^ string_of_typ t1 ^ "`")
+
+let elab_binop env op t1 t2 at : Il.binop * typ =
+  let ops = infer_binop op in
+  match
+    List.find_opt (fun (_, t) ->
+      sub_typ env t1 (t $ at) && sub_typ env t2 (t $ at)) ops
+  with
+  | Some (op', t) -> op', t $ at
+  | None ->
+    error at ("operator " ^ string_of_binop op ^ " is not defined for types `" ^
+      string_of_typ t1 ^ "` and `" ^ string_of_typ t2 ^ "`")
+
+let elab_cmpop env op
+  : [`Poly of Il.cmpop | `Over of typ -> typ -> region -> Il.cmpop * typ] =
+  match infer_cmpop op with
+  | `Poly op' -> `Poly op'
+  | `Over ops -> `Over (fun t1 t2 at ->
+    match
+      List.find_opt (fun (_, t) ->
+        sub_typ env t1 (t $ at) && sub_typ env t2 (t $ at)) ops
+    with
+    | Some (op', t) -> op', t $ at
+    | None ->
+      error at ("operator " ^ string_of_cmpop op ^ " is not defined for types `" ^
+        string_of_typ t1 ^ "` and `" ^ string_of_typ t2 ^ "`")
+    )
 
 let merge_mixop mixop1 mixop2 =
   match mixop1, mixop2 with
@@ -355,10 +432,10 @@ let rec elab_iter env iter : Il.iter =
   | ListN (e, id_opt) ->
     Option.iter (fun id ->
       let t = find "variable" env.vars (prefix_id id) in
-      if not (equiv_typ env t (NatT $ id.at)) then
-        error_typ e.at "iteration index" (NatT $ id.at)
+      if not (equiv_typ env t (NumT NatT $ id.at)) then
+        error_typ e.at "iteration index" (NumT NatT $ id.at)
     ) id_opt;
-    Il.ListN (elab_exp env e (NatT $ e.at), id_opt)
+    Il.ListN (elab_exp env e (NumT NatT $ e.at), id_opt)
 
 
 (* Types *)
@@ -371,7 +448,7 @@ and elab_typ env t : Il.typ =
     | _ -> Il.VarT id $ t.at
     )
   | BoolT -> Il.BoolT $ t.at
-  | NatT -> Il.NatT $ t.at
+  | NumT t' -> Il.NumT (elab_numtyp t') $ t.at
   | TextT -> Il.TextT $ t.at
   | ParenT t1 -> elab_typ env t1
   | TupT ts -> Il.TupT (List.map (elab_typ env) ts) $ t.at
@@ -400,7 +477,7 @@ and elab_typ_definition env id t : Il.deftyp =
     Il.VariantT tcs'
   | RangeT tes ->
     let _ = map_nl_list (elab_typenum env) tes in
-    Il.AliasT (Il.NatT $ t.at)
+    Il.AliasT (Il.NumT Il.NatT $ t.at)
   | _ ->
     match elab_typ_notation env t with
     | false, _mixop, ts' -> Il.AliasT (tup_typ' ts' t.at)
@@ -474,150 +551,199 @@ and elab_typcase env at (atom, (ts, prems), hints) : Il.typcase =
   )
 
 and elab_typenum env (e, eo) =
-  (* TODO: for now, we simplify ranges to nat *)
-  let _e' = elab_exp env e (NatT $ e.at) in
-  let _eo' = Option.map (fun e2 -> elab_exp env e2 (NatT $ e2.at)) eo in
+  (* TODO: for now, we simplify ranges to nat or int *)
+  let _e' = elab_exp env e (NumT IntT $ e.at) in
+  let _eo' = Option.map (fun e2 -> elab_exp env e2 (NumT IntT $ e2.at)) eo in
   ()
 
-and (!!) env t = elab_typ env t
 and (!!!) env t = let _, _, ts' = elab_typ_notation env t in tup_typ' ts' t.at
 
 
 (* Expressions *)
 
-and infer_unop = function
-  | NotOp -> BoolT
-  | PlusOp | MinusOp -> NatT
+and infer_exp env e : Il.exp * typ =
+  let e', t = infer_exp' env e in
+  e' $$ e.at % elab_typ env t, t
 
-and infer_binop = function
-  | AndOp | OrOp | ImplOp | EquivOp -> BoolT
-  | AddOp | SubOp | MulOp | DivOp | ExpOp -> NatT
-
-and infer_cmpop = function
-  | EqOp | NeOp -> None
-  | LtOp | GtOp | LeOp | GeOp -> Some NatT
-
-(* TODO: turn this into a properly bidirectional formulation *)
-and infer_exp env e : typ =
+and infer_exp' env e : Il.exp' * typ =
+  (*
+  Printf.printf "[infer %s] %s\n%!"
+    (string_of_region e.at) (string_of_exp e);
+  *)
   match e.it with
-  | VarE id -> find "variable" env.vars (prefix_id id)
-  | AtomE _ -> error e.at "cannot infer type of atom"
-  | BoolE _ -> BoolT $ e.at
-  | NatE _ | HexE _ | CharE _ | LenE _ -> NatT $ e.at
-  | TextE _ -> TextT $ e.at
-  | UnE (op, _) -> infer_unop op $ e.at
-  | BinE (_, op, _) -> infer_binop op $ e.at
-  | CmpE _ -> BoolT $ e.at
-  | IdxE (e1, _) -> as_list_typ "expression" env Infer (infer_exp env e1) e1.at
-  | SliceE (e1, _, _)
-  | UpdE (e1, _, _)
-  | ExtE (e1, _, _)
-  | CommaE (e1, _)
-  | CompE (e1, _) -> infer_exp env e1
-  | StrE _ -> error e.at "cannot infer type of record"
+  | VarE id ->
+    Il.VarE id, find "variable" env.vars (prefix_id id)
+  | AtomE _ ->
+    error e.at "cannot infer type of atom"
+  | BoolE b ->
+    Il.BoolE b, BoolT $ e.at
+  | NatE n | HexE n | CharE n ->
+    Il.NatE n, NumT NatT $ e.at
+  | TextE s ->
+    Il.TextE s, TextT $ e.at
+  | UnE (op, e1) ->
+    let e1', t1 = infer_exp env e1 in
+    let op', t = elab_unop env op t1 e.at in
+    Il.UnE (op', cast_exp "operand" env e1' t1 t), t
+  | BinE (e1, op, e2) ->
+    let e1', t1 = infer_exp env e1 in
+    let e2', t2 = infer_exp env e2 in
+    let op', t = elab_binop env op t1 t2 e.at in
+    Il.BinE (op',
+      cast_exp "operand" env e1' t1 t,
+      cast_exp "operand" env e2' t2 t
+    ), t
+  | CmpE (e1, op, ({it = CmpE (e21, _, _); _} as e2)) ->
+    let e1', _t1 = infer_exp env (CmpE (e1, op, e21) $ e.at) in
+    let e2', _t2 = infer_exp env e2 in
+    Il.BinE (Il.AndOp, e1', e2'), BoolT $ e.at
+  | CmpE (e1, op, e2) ->
+    (match elab_cmpop env op with
+    | `Poly op' ->
+      let e1', t1 = infer_exp env e1 in
+      let e2' = elab_exp env e2 t1 in
+      Il.CmpE (op', e1', e2'), BoolT $ e.at
+    | `Over elab_cmpop'  ->
+      let e1', t1 = infer_exp env e1 in
+      let e2', t2 = infer_exp env e2 in
+      let op', t = elab_cmpop' t1 t2 e.at in
+      Il.CmpE (op',
+        cast_exp "operand" env e1' t1 t,
+        cast_exp "operand" env e2' t2 t
+      ), BoolT $ e.at
+    )
+  | IdxE (e1, e2) ->
+    let e1', t1 = infer_exp env e1 in
+    let t = as_list_typ "expression" env Infer t1 e1.at in
+    let e2' = elab_exp env e2 (NumT NatT $ e2.at) in
+    Il.IdxE (e1', e2'), t
+  | SliceE (e1, e2, e3) ->
+    let e1', t1 = infer_exp env e1 in
+    let _t' = as_list_typ "expression" env Infer t1 e1.at in
+    let e2' = elab_exp env e2 (NumT NatT $ e2.at) in
+    let e3' = elab_exp env e3 (NumT NatT $ e3.at) in
+    Il.SliceE (e1', e2', e3'), t1
+  | UpdE (e1, p, e2) ->
+    let e1', t1 = infer_exp env e1 in
+    let p', t2 = elab_path env p t1 in
+    let e2' = elab_exp env e2 t2 in
+    Il.UpdE (e1', p', e2'), t1
+  | ExtE (e1, p, e2) ->
+    let e1', t1 = infer_exp env e1 in
+    let p', t2 = elab_path env p t1 in
+    let _t21 = as_list_typ "path" env Infer t2 p.at in
+    let e2' = elab_exp env e2 t2 in
+    Il.ExtE (e1', p', e2'), t1
+  | StrE _ ->
+    error e.at "cannot infer type of record"
   | DotE (e1, atom) ->
-    let t1 = infer_exp env e1 in
+    let e1', t1 = infer_exp env e1 in
     let tfs = as_struct_typ "expression" env Infer t1 e1.at in
     let t, _prems = find_field tfs atom e1.at in
-    t
+    Il.DotE (e1', elab_atom atom), t
+  | CommaE (e1, e2) ->
+    let e1', t1 = infer_exp env e1 in
+    let tfs = as_struct_typ "expression" env Infer t1 e1.at in
+    (* TODO: this is a bit of a hack *)
+    (match e2.it with
+    | SeqE ({it = AtomE atom; at; _} :: es2) ->
+      let _t2 = find_field tfs atom at in
+      let e2 = match es2 with [e2] -> e2 | _ -> SeqE es2 $ e2.at in
+      let e2' = elab_exp env (StrE [Elem (atom, e2)] $ e2.at) t1 in
+      Il.CompE (e1', e2'), t1
+    | _ -> failwith "unimplemented: infer CommaE"
+    )
+  | CompE (e1, e2) ->
+    let e1', t1 = infer_exp env e1 in
+    let _ = as_struct_typ "record" env Infer t1 e.at in
+    let e2' = elab_exp env e2 t1 in
+    Il.CompE (e1', e2'), t1
+  | LenE e1 ->
+    let e1', t1 = infer_exp env e1 in
+    let _t11 = as_list_typ "expression" env Infer t1 e1.at in
+    Il.LenE e1', NumT NatT $ e.at
+  | SizeE id ->
+    let _ = find "grammar" env.syms id in
+    NatE 0, NumT NatT $ e.at
+  | ParenE (e1, _) ->
+    infer_exp' env e1
+  | TupE es ->
+    let es', ts = List.split (List.map (infer_exp env) es) in
+    Il.TupE es', TupT ts $ e.at
+  | CallE (id, e2) ->
+    let t2, t, _ = find "function" env.defs id in
+    let e2' = elab_exp env e2 t2 in
+    Il.CallE (id, e2'), t
   | EpsE -> error e.at "cannot infer type of empty sequence"
   | SeqE _ -> error e.at "cannot infer type of expression sequence"
-  | TupE es -> TupT (List.map (infer_exp env) es) $ e.at
-  | ParenE (e1, _) -> ParenT (infer_exp env e1) $ e.at
-  | CallE (id, _) -> let _, t2, _ = find "function" env.defs id in t2
   | InfixE _ -> error e.at "cannot infer type of infix expression"
   | BrackE _ -> error e.at "cannot infer type of bracket expression"
   | IterE (e1, iter) ->
-    let iter' = match iter with ListN _ -> List | iter' -> iter' in
-    IterT (infer_exp env e1, iter') $ e.at
+    let e1', t1 = infer_exp env e1 in
+    let iter' = elab_iterexp env iter in
+    Il.IterE (e1', iter'), IterT (t1, match iter with ListN _ -> List | _ -> iter) $ e.at
   | HoleE _ -> error e.at "misplaced hole"
   | FuseE _ -> error e.at "misplaced token concatenation"
 
 
 and elab_exp env e t : Il.exp =
+  let e' = elab_exp' env e t in
+  e' $$ e.at % elab_typ env t
+
+and elab_exp' env e t : Il.exp' =
   (*
   Printf.printf "[elab %s] %s  :  %s\n%!"
     (string_of_region e.at) (string_of_exp e) (string_of_typ t);
   *)
   match e.it with
-  | VarE id ->
-    let t' = infer_exp env e in
-    cast_exp "variable" env (Il.VarE id $$ e.at % !!env t') t' t
-  | BoolE b ->
-    let t' = infer_exp env e in
-    cast_exp "boolean" env (Il.BoolE b $$ e.at % !!env t') t' t
-  | NatE n | HexE n | CharE n ->
-    let t' = infer_exp env e in
-    cast_exp "number" env (Il.NatE n $$ e.at % !!env t') t' t
-  | TextE s ->
-    let t' = infer_exp env e in
-    cast_exp "text" env (Il.TextE s $$ e.at % !!env t') t' t
-  | UnE (op, e1) ->
-    let t' = infer_unop op $ e.at in
-    let e1' = elab_exp env e1 t' in
-    let e' = Il.UnE (elab_unop op, e1') $$ e.at % !!env t' in
-    cast_exp "unary operator" env e' t' t
-  | BinE (e1, op, e2) ->
-    let t' = infer_binop op $ e.at in
-    let e1' = elab_exp env e1 t' in
-    let e2' = elab_exp env e2 t' in
-    let e' = Il.BinE (elab_binop op, e1', e2') $$ e.at % !!env t' in
-    cast_exp "binary operator" env e' t' t
-  | CmpE (e1, op, e2) ->
-    let t1' =
-      match infer_cmpop op with
-      | Some t1' -> t1' $ e.at
-      | None -> infer_exp env e1
-    in
-    let e1' = elab_exp env e1 t1' in
-    let t' = BoolT $ e.at in
-    let e' =
-      match e2.it with
-      | CmpE (e21, _, _) ->
-        let e21' = elab_exp env e21 t1' in
-        let e2' = elab_exp env e2 (BoolT $ e2.at) in
-        Il.BinE (Il.AndOp,
-          Il.CmpE (elab_cmpop op, e1', e21') $$ e1.at % !!env t' , e2') $$ e.at % !!env t'
-      | _ ->
-        let e2' = elab_exp env e2 t1' in
-        Il.CmpE (elab_cmpop op, e1', e2') $$ e.at % !!env t'
-    in
-    cast_exp "comparison operator" env e' t' t
-  | IdxE (e1, e2) ->
-    let t1 = infer_exp env e1 in
-    let t' = as_list_typ "expression" env Infer t1 e1.at in
-    let e1' = elab_exp env e1 t1 in
-    let e2' = elab_exp env e2 (NatT $ e2.at) in
-    let e' = Il.IdxE (e1', e2') $$ e.at % !!env t' in
-    cast_exp "list element" env e' t' t
+  | VarE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "variable" env e' t' t
+  | BoolE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "boolean" env e' t' t
+  | NatE _ | HexE _ | CharE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "number" env e' t' t
+  | TextE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "text" env e' t' t
+  | UnE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "unary operator" env e' t' t
+  | BinE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "binary operator" env e' t' t
+  | CmpE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "comparison operator" env e' t' t
+  | IdxE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "list element" env e' t' t
   | SliceE (e1, e2, e3) ->
     let _t' = as_list_typ "expression" env Check t e1.at in
     let e1' = elab_exp env e1 t in
-    let e2' = elab_exp env e2 (NatT $ e2.at) in
-    let e3' = elab_exp env e3 (NatT $ e3.at) in
-    Il.SliceE (e1', e2', e3') $$ e.at % !!env t
+    let e2' = elab_exp env e2 (NumT NatT $ e2.at) in
+    let e3' = elab_exp env e3 (NumT NatT $ e3.at) in
+    Il.SliceE (e1', e2', e3')
   | UpdE (e1, p, e2) ->
     let e1' = elab_exp env e1 t in
     let p', t2 = elab_path env p t in
     let e2' = elab_exp env e2 t2 in
-    Il.UpdE (e1', p', e2') $$ e.at % !!env t
+    Il.UpdE (e1', p', e2')
   | ExtE (e1, p, e2) ->
     let e1' = elab_exp env e1 t in
     let p', t2 = elab_path env p t in
     let _t21 = as_list_typ "path" env Check t2 p.at in
     let e2' = elab_exp env e2 t2 in
-    Il.ExtE (e1', p', e2') $$ e.at % !!env t
+    Il.ExtE (e1', p', e2')
   | StrE efs ->
     let tfs = as_struct_typ "record" env Check t e.at in
     let efs' = elab_expfields env (filter_nl efs) tfs e.at in
-    Il.StrE efs' $$ e.at % !!env t
-  | DotE (e1, atom) ->
-    let t1 = infer_exp env e1 in
-    let e1' = elab_exp env e1 t1 in
-    let tfs = as_struct_typ "expression" env Infer t1 e1.at in
-    let t', _prems = find_field tfs atom e1.at in
-    let e' = Il.DotE (e1', elab_atom atom) $$ e.at % !!env t' in
-    cast_exp "field" env e' t' t
+    Il.StrE efs'
+  | DotE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "projection" env e' t' t
   | CommaE (e1, e2) ->
     let e1' = elab_exp env e1 t in
     let tfs = as_struct_typ "expression" env Check t e1.at in
@@ -627,40 +753,41 @@ and elab_exp env e t : Il.exp =
       let _t2 = find_field tfs atom at in
       let e2 = match es2 with [e2] -> e2 | _ -> SeqE es2 $ e2.at in
       let e2' = elab_exp env (StrE [Elem (atom, e2)] $ e2.at) t in
-      Il.CompE (e1', e2') $$ e.at % !!env t
-    | _ -> failwith "unimplemented check CommaE"
+      Il.CompE (e1', e2')
+    | _ -> failwith "unimplemented: check CommaE"
     )
   | CompE (e1, e2) ->
     let _ = as_struct_typ "record" env Check t e.at in
     let e1' = elab_exp env e1 t in
     let e2' = elab_exp env e2 t in
-    Il.CompE (e1', e2') $$ e.at % !!env t
-  | LenE e1 ->
-    let t1 = infer_exp env e1 in
-    let _t11 = as_list_typ "expression" env Infer t1 e1.at in
-    let e1' = elab_exp env e1 t1 in
-    let e' = Il.LenE e1' $$ e.at % !!env (NatT $ e.at) in
-    cast_exp "list length" env e' (NatT $ e.at) t
+    Il.CompE (e1', e2')
+  | LenE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "list length" env e' t' t
+  | SizeE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "expansion length" env e' t' t
   | ParenE (e1, true) when is_iter_typ env t ->
     (* Significant parentheses indicate a singleton *)
     let t1, _iter = as_iter_typ "expression" env Check t e.at in
     let e1' = elab_exp env e1 t1 in
-    cast_exp "expression" env e1' t1 t
+    cast_exp' "expression" env e1' t1 t
   | ParenE (e1, _) ->
-    elab_exp env e1 t
+    elab_exp' env e1 t
   | TupE es ->
     let ts = as_tup_typ "tuple" env Check t e.at in
-    let es' = elab_exps env es ts e.at in
-    Il.TupE es' $$ e.at % !!env t
-  | CallE (id, e2) ->
-    let t2, t', _ = find "function" env.defs id in
-    let e2' = elab_exp env e2 t2 in
-    let e' = Il.CallE (id, e2') $$ e.at % !!env t' in
-    cast_exp "expression" env e' t' t
-  | SeqE [_] -> assert false  (* sequences cannot be singleton *)
+    if List.length es <> List.length ts then
+      error e.at "arity mismatch for expression list";
+    let es' = List.map2 (elab_exp env) es ts in
+    Il.TupE es'
+  | CallE _ ->
+    let e', t' = infer_exp env e in
+    cast_exp' "function application" env e' t' t
+  | SeqE [_] ->
+    assert false  (* sequences cannot be singleton *)
   | EpsE | SeqE _ when is_iter_typ env t ->
     let e1 = unseq_exp e in
-    elab_exp_iter env e1 (as_iter_typ "" env Check t e.at) t e.at
+    elab_exp_iter' env e1 (as_iter_typ "" env Check t e.at) t e.at
   | EpsE
   | AtomE _
   | InfixE _
@@ -670,10 +797,10 @@ and elab_exp env e t : Il.exp =
      * either a defined notation/variant type or (for SeqE) an iteration type;
      * the latter case is already captured above *)
     if is_notation_typ env t then
-      elab_exp_notation env e (as_notation_typ "" env Check t e.at) t
+      (elab_exp_notation env e (as_notation_typ "" env Check t e.at) t).it
     else if is_variant_typ env t then
-      elab_exp_variant env (unseq_exp e)
-        (fst (as_variant_typ "" env Check t e.at)) t e.at
+      (elab_exp_variant env (unseq_exp e)
+        (fst (as_variant_typ "" env Check t e.at)) t e.at).it
     else
       error_typ e.at "expression" t
   | IterE (e1, iter2) ->
@@ -684,14 +811,9 @@ and elab_exp env e t : Il.exp =
       error_typ e.at "iteration expression" t;
     let e1' = elab_exp env e1 t1 in
     let iter2' = elab_iterexp env iter2 in
-    Il.IterE (e1', iter2') $$ e.at % !!env t
+    Il.IterE (e1', iter2')
   | HoleE _ -> error e.at "misplaced hole"
   | FuseE _ -> error e.at "misplaced token fuse"
-
-and elab_exps env es ts at : Il.exp list =
-  if List.length es <> List.length ts then
-    error at "arity mismatch for expression list";
-  List.map2 (elab_exp env) es ts
 
 and elab_expfields env efs tfs at : Il.expfield list =
   match efs, tfs with
@@ -703,13 +825,17 @@ and elab_expfields env efs tfs at : Il.expfield list =
   | _, (atom, (t, _prems), _)::tfs2 ->
     let atom' = string_of_atom atom in
     let e' =
-      cast_empty ("omitted record field `" ^ atom' ^ "`") env t at (!!env t) in
+      cast_empty ("omitted record field `" ^ atom' ^ "`") env t at (elab_typ env t) in
     let efs2' = elab_expfields env efs tfs2 at in
     (elab_atom atom, e') :: efs2'
   | (atom, e)::_, [] ->
     error_atom e.at atom "unexpected record field"
 
 and elab_exp_iter env es (t1, iter) t at : Il.exp =
+  let e' = elab_exp_iter' env es (t1, iter) t at in
+  e' $$ at % elab_typ env t
+
+and elab_exp_iter' env es (t1, iter) t at : Il.exp' =
   (*
   Printf.printf "[iteration %s] %s  :  %s = (%s)%s\n%!"
     (string_of_region at)
@@ -722,19 +848,19 @@ and elab_exp_iter env es (t1, iter) t at : Il.exp =
   | {it = AtomE atom; at = at1; _}::_, _ when is_variant_typ env t1 &&
       case_has_args env t1 atom at1 ->
     let cases, _dots = as_variant_typ "" env Check t1 at in
-    lift_exp' (elab_exp_variant env es cases t1 at) iter $$ at % !!env t
+    lift_exp' (elab_exp_variant env es cases t1 at) iter
 
   (* An empty sequence represents the None case for options *)
   | [], Opt ->
-    Il.OptE None $$ at % !!env t
+    Il.OptE None
   (* An empty sequence represents the Nil case for lists *)
   | [], List ->
-    Il.ListE [] $$ at % !!env t
+    Il.ListE []
   (* All other elements are either splices or (by cast injection) elements *)
   | e1::es2, List ->
     let e1' = elab_exp env e1 t in
     let e2' = elab_exp_iter env es2 (t1, iter) t at in
-    cat_exp' e1' e2' $$ at % !!env t
+    cat_exp' e1' e2'
 
   | _, _ ->
     error_typ at "expression" t
@@ -748,7 +874,7 @@ and elab_exp_notation env e nt t : Il.exp =
   let e' = tup_exp' (elab_exp_notation' env e nt) e.at in
   match elab_typ_notation env nt with
   | false, _, _ -> e'
-  | true, mixop, _ -> Il.MixE (mixop, e') $$ e.at % !!env t
+  | true, mixop, _ -> Il.MixE (mixop, e') $$ e.at % elab_typ env t
 
 and elab_exp_notation' env e t : Il.exp list =
   (*
@@ -818,7 +944,7 @@ and elab_exp_notation' env e t : Il.exp list =
   (* Significant parentheses indicate a singleton *)
   | ParenE (e1, true), IterT (t1, iter) ->
     let es' = elab_exp_notation' env e1 t1 in
-    [lift_exp' (tup_exp' es' e.at) iter $$ e.at % !!env t]
+    [lift_exp' (tup_exp' es' e.at) iter $$ e.at % elab_typ env t]
   (* Elimination forms are considered splices *)
   | (IdxE _ | SliceE _ | UpdE _ | ExtE _ | DotE _ | CallE _), IterT _ ->
     [elab_exp env e t]
@@ -837,6 +963,11 @@ and elab_exp_notation' env e t : Il.exp list =
     [elab_exp env e t]
 
 and elab_exp_notation_iter env es (t1, iter) t at : Il.exp =
+  let e' = elab_exp_notation_iter' env es (t1, iter) t at in
+  let _, _, ts' = elab_typ_notation env t in
+  e' $$ at % tup_typ' ts' t.at
+
+and elab_exp_notation_iter' env es (t1, iter) t at : Il.exp' =
   (*
   Printf.printf "[niteration %s] %s  :  %s\n%!"
     (string_of_region at)
@@ -849,20 +980,20 @@ and elab_exp_notation_iter env es (t1, iter) t at : Il.exp =
   | {it = AtomE atom; at = at1; _}::_, iter when is_variant_typ env t1 &&
       case_has_args env t1 atom at1 ->
     let cases, _ = as_variant_typ "expression" env Check t1 at in
-    lift_exp' (elab_exp_variant env es cases t1 at) iter $$ at % !!!env t
+    lift_exp' (elab_exp_variant env es cases t1 at) iter
 
   (* An empty sequence represents the None case for options *)
   | [], Opt ->
-    Il.OptE None $$ at % !!!env t
+    Il.OptE None
   (* An empty sequence represents the Nil case for lists *)
   | [], List ->
-    Il.ListE [] $$ at % !!!env t
+    Il.ListE []
   (* All other elements are either splices or (by cast injection) elements;
    * nested expressions must be lifted into a tuple *)
   | e1::es2, List ->
     let es1' = elab_exp_notation' env e1 t in
     let e2' = elab_exp_notation_iter env es2 (t1, iter) t at in
-    cat_exp' (tup_exp' es1' e1.at) e2' $$ at % !!!env t
+    cat_exp' (tup_exp' es1' e1.at) e2'
 
   | _, _ ->
     error_typ at "expression" t
@@ -889,32 +1020,37 @@ and elab_exp_variant env es cases t at : Il.exp =
     let e2 = SeqE es $ at in
     let es' = elab_exp_notation' env e2 (SeqT ts $ t.at) in
     let t2 = expand_singular' env t.it $ at in
+    let t2' = elab_typ env t2 in
     cast_exp "variant case" env
-      (Il.CaseE (elab_atom atom, tup_exp' es' at) $$ at % !!env t2) t2 t
+      (Il.CaseE (elab_atom atom, tup_exp' es' at) $$ at % t2') t2 t
   | _ ->
     error_typ at "expression" t
 
 
 and elab_path env p t : Il.path * typ =
+  let p', t' = elab_path' env p t in
+  p' $$ p.at % elab_typ env t', t'
+
+and elab_path' env p t : Il.path' * typ =
   match p.it with
   | RootP ->
-    Il.RootP $$ p.at % !!env t, t
+    Il.RootP, t
   | IdxP (p1, e1) ->
     let p1', t1 = elab_path env p1 t in
-    let e1' = elab_exp env e1 (NatT $ e1.at) in
+    let e1' = elab_exp env e1 (NumT NatT $ e1.at) in
     let t' = as_list_typ "path" env Check t1 p1.at in
-    Il.IdxP (p1', e1') $$ p.at % !!env t', t'
+    Il.IdxP (p1', e1'), t'
   | SliceP (p1, e1, e2) ->
     let p1', t1 = elab_path env p1 t in
-    let e1' = elab_exp env e1 (NatT $ e1.at) in
-    let e2' = elab_exp env e2 (NatT $ e2.at) in
+    let e1' = elab_exp env e1 (NumT NatT $ e1.at) in
+    let e2' = elab_exp env e2 (NumT NatT $ e2.at) in
     let _ = as_list_typ "path" env Check t1 p1.at in
-    Il.SliceP (p1', e1', e2') $$ p.at % !!env t1, t1
+    Il.SliceP (p1', e1', e2'), t1
   | DotP (p1, atom) ->
     let p1', t1 = elab_path env p1 t in
     let tfs = as_struct_typ "path" env Check t1 p1.at in
     let t', _prems = find_field tfs atom p1.at in
-    Il.DotP (p1', elab_atom atom) $$ p.at % !!env t', t'
+    Il.DotP (p1', elab_atom atom), t'
 
 
 and cast_empty phrase env t at t' : Il.exp =
@@ -924,6 +1060,10 @@ and cast_empty phrase env t at t' : Il.exp =
   | _ -> error_typ at phrase t
 
 and cast_exp phrase env e' t1 t2 : Il.exp =
+  let e'' = cast_exp' phrase env e' t1 t2 in
+  e'' $$ e'.at % elab_typ env t2
+
+and cast_exp' phrase env e' t1 t2 : Il.exp' =
   (*
   Printf.printf "[cast %s] (%s) <: (%s)  >>  (%s) <: (%s)  eq=%b\n%!"
     (string_of_region e'.at)
@@ -932,14 +1072,18 @@ and cast_exp phrase env e' t1 t2 : Il.exp =
     (string_of_typ (expand env t2 $ t2.at))
     (equiv_typ env t1 t2);
   *)
-  if equiv_typ env t1 t2 then e' else
-  match expand env t2 with
-  | IterT (t21, Opt) ->
-    Il.OptE (Some (cast_exp_variant phrase env e' t1 t21)) $$ e'.at % !!env t2
-  | IterT (t21, (List | List1)) ->
-    Il.ListE [cast_exp_variant phrase env e' t1 t21] $$ e'.at % !!env t2
-  | _ ->
-    cast_exp_variant phrase env e' t1 t2
+  if equiv_typ env t1 t2 then
+    e'.it
+  else if sub_typ env t1 t2 then
+    Il.SubE (e', elab_typ env t1, elab_typ env t2)
+  else
+    match expand env t2 with
+    | IterT (t21, Opt) ->
+      Il.OptE (Some (cast_exp phrase env e' t1 t21))
+    | IterT (t21, (List | List1)) ->
+      Il.ListE [cast_exp phrase env e' t1 t21]
+    | _ ->
+      (cast_exp_variant phrase env e' t1 t2).it
 
 and cast_exp_variant phrase env e' t1 t2 : Il.exp =
   if equiv_typ env t1 t2 then e' else
@@ -958,12 +1102,12 @@ and cast_exp_variant phrase env e' t1 t2 : Il.exp =
       ) cases1
     with Error (_, msg) -> error_typ2 e'.at phrase t1 t2 (", " ^ msg)
     );
-    Il.SubE (e', elab_typ env t1, elab_typ env t2) $$ e'.at % !!env t2
+    Il.SubE (e', elab_typ env t1, elab_typ env t2) $$ e'.at % elab_typ env t2
   else
     error_typ2 e'.at phrase t1 t2 ""
 
 
-and elab_iterexp env iter =
+and elab_iterexp env iter : Il.iterexp =
   (elab_iter env iter, [])
 
 
@@ -987,6 +1131,102 @@ and elab_prem env prem : Il.premise =
     Il.IterPr (prem1', iter') $ prem.at
 
 
+(* Grammars *)
+
+and elab_gramargs env gs ps at : env =
+  match gs, ps with
+  | [], [] -> env
+  | g::_, [] -> error g.at "superfluous grammar parameter"
+  | [], _::_ -> error at "too few grammar parameter"
+  | g::gs', p::ps' ->
+    let env' =
+      match p.it with
+      | VarP id ->
+        let t = find "variable" env.vars (prefix_id id) in
+        let _e' = elab_exp env (exp_of_sym g) t in
+        env
+      | GramP (_id1, id2, iters) ->
+        match g.it with
+        | VarG (id, gs') ->
+          let ps', t, _gram = find "grammar" env.syms id in
+          let rec check_iters t iters =
+            match t.it, iters with
+            | _, [] -> t
+            | IterT (t', iter), iter'::iters' when Eq.eq_iter iter iter' ->
+              check_iters t' iters'
+            | _, _ ->
+              error g.at "inconsistent multiplicity for grammar argument";
+          in
+          let t' = check_iters t (List.rev iters) in
+          let env' = elab_gramargs env gs' ps' g.at in
+          let dt' =  Il.AliasT (elab_typ env' t') $ t.at in
+          { env' with
+            typs = bind "syntax type" env'.typs id2 (Either.Right (t, dt'));
+            vars = bind "variable" env'.vars id2 (VarT id2 $ id2.at);
+          }
+        | _ ->
+          error g.at "malformed grammar argument"
+    in elab_gramargs env' gs' ps' at
+
+and elab_sym env g : typ * env =
+  match g.it with
+  | VarG (id, gs) ->
+    let ps, t, _gram = find "grammar" env.syms id in
+    let env' = elab_gramargs env gs ps g.at in
+    t, env'
+  | NatG _ | HexG _ | CharG _ -> NumT NatT $ g.at, env
+  | TextG _ -> TextT $ g.at, env
+  | EpsG -> TupT [] $ g.at, env
+  | SeqG gs ->
+    let _ts, env' = elab_sym_list env (filter_nl gs) in
+    TupT [] $ g.at, env'
+  | AltG gs ->
+    let _ = elab_sym_list env (filter_nl gs) in
+    TupT [] $ g.at, env
+  | RangeG (g1, g2) ->
+    let t1, env1 = elab_sym env g1 in
+    let t2, env2 = elab_sym env g2 in
+    if env1 != env then
+      error g1.at "invalid symbol in range";
+    if env2 != env then
+      error g2.at "invalid symbol in range";
+    if not (equiv_typ env t1 t2) then
+      error_typ2 g2.at "range item" t2 t1 " of other range item";
+    TupT [] $ g.at, env
+  | ParenG g1 -> elab_sym env g1
+  | TupG gs ->
+    let ts, env' = elab_sym_list env gs in
+    TupT ts $ g.at, env'
+  | IterG (g1, iter) ->
+    let t1, env1 = elab_sym env g1 in
+    let _iter' = elab_iterexp env iter in
+    IterT (t1, match iter with Opt -> Opt | _ -> List) $ g.at, env1
+  | ArithG e ->
+    let _e', t = infer_exp env e in
+    t, env
+  | AttrG (g1, e) ->
+    let t1, env1 = elab_sym env g1 in
+    let _e' = elab_exp env1 e t1 in
+    TupT [] $ g.at, env
+
+and elab_sym_list env = function
+  | [] -> [], env
+  | g::gs ->
+    let t, env' = elab_sym env g in
+    let ts, env'' = elab_sym_list env' gs in
+    t::ts, env''
+
+and elab_prod env prod t =
+  let (g, e, prems) = prod.it in
+  let _e' = elab_exp env e t in
+  let _prems' = map_nl_list (elab_prem env) prems in
+  elab_sym env g
+
+and elab_gram env gram t =
+  let (_dots1, prods, _dots2) = gram.it in
+  iter_nl_list (fun prod -> ignore (elab_prod env prod t)) prods
+
+
 (* Definitions *)
 
 and make_binds env free dims at : Il.binds =
@@ -998,17 +1238,42 @@ and make_binds env free dims at : Il.binds =
   ) (Set.elements free)
 
 
+let elab_params env ps : env =
+  List.fold_left (fun env p ->
+    match p.it with
+    | VarP _id -> env
+    | GramP (id1, id2, iters) ->
+      let _ = List.map (elab_iter env) iters in
+      let t = List.fold_left (fun t iter -> IterT(t, iter) $ p.at) (VarT id2 $ id2.at) iters in
+      { env with
+        typs = bind "syntax type" env.typs id2 (Either.Left Ok);
+        vars = bind "variable" env.vars id2 (VarT id2 $ id2.at);
+        syms = bind "grammar" env.syms id1 ([], t, None);
+      }
+  ) env ps
+
+
 let infer_typ_definition _env t : syn_typ =
   match t.it with
   | StrT _ | CaseT _ -> Either.Left Ok
   | _ -> Either.Left Bad
 
-let infer_def env d =
+let infer_syndef env d =
   match d.it with
   | SynD (id1, _id2, t, _hints) ->
     if not (bound env.typs id1) then (
       env.typs <- bind "syntax type" env.typs id1 (infer_typ_definition env t);
       env.vars <- bind "variable" env.vars id1 (VarT id1 $ id1.at);
+    )
+  | _ -> ()
+
+let infer_gramdef env d =
+  match d.it with
+  | GramD (id1, _id2, ps, t, _gram, _hints) ->
+    if not (bound env.syms id1) then (
+      let env' = elab_params env ps in
+      let _t' = elab_typ env' t in
+      env.syms <- bind "grammar" env.syms id1 (ps, t, None);
     )
   | _ -> ()
 
@@ -1023,7 +1288,7 @@ let elab_hintdef _env hd : Il.def list =
   | DecH (id, hints) ->
     if hints = [] then [] else
     [Il.HintD (Il.DecH (id, elab_hints hints) $ hd.at) $ hd.at]
-  | AtomH _ | VarH _ ->
+  | GramH _ | AtomH _ | VarH _ ->
     []
 
 let elab_def env d : Il.def list =
@@ -1054,6 +1319,7 @@ let elab_def env d : Il.def list =
     env.typs <- rebind "syntax type" env.typs id1 (Either.Right (t1, dt'));
     (if not closed then [] else [Il.SynD (id1, dt') $ d.at])
       @ elab_hintdef env (SynH (id1, id2, hints) $ d.at)
+  | GramD _ -> []
   | RelD (id, t, hints) ->
     let _, mixop, ts' = elab_typ_notation env t in
     env.rels <- bind "relation" env.rels id (t, []);
@@ -1077,8 +1343,7 @@ let elab_def env d : Il.def list =
     env.vars <- bind "variable" env.vars id t;
     []
   | DecD (id, e1, t2, hints) ->
-    let t1 = infer_exp env e1 in
-    let _exp1' = elab_exp env e1 t1 in
+    let _e1', t1 = infer_exp env e1 in
     let t1' = elab_typ env t1 in
     let t2' = elab_typ env t2 in
     env.defs <- bind "function" env.defs id (t1, t2, []);
@@ -1111,6 +1376,33 @@ let elab_def env d : Il.def list =
     []
   | HintD hd ->
     elab_hintdef env hd
+
+let elab_gramdef env d =
+  match d.it with
+  | GramD (id1, _id2, ps, t, gram, _hints) ->
+    let env' = elab_params env ps in
+    let _t' = elab_typ env' t in
+    elab_gram env' gram t;
+    let ps1, t1, gram1_opt = find "grammar" env.syms id1 in
+    let gram' =
+      match gram1_opt, gram.it with
+      | None, (Dots, _, _) ->
+        error_id id1 "extension of not yet defined grammar"
+      | None, _ ->
+        gram
+      | Some {it = (dots1, prods1, Dots); at; _}, (Dots, prods2, dots2) ->
+        if not Eq.(eq_list eq_param ps ps1) then
+          error d.at "grammar parameters differ from previous fragment";
+        if not (equiv_typ env' t t1) then
+          error_typ2 d.at "grammar" t1 t " of previous fragment";
+        (dots1, prods1 @ prods2, dots2) $ over_region [at; t.at]
+      | Some _, (Dots, _, _) ->
+        error_id id1 "extension of non-extensible grammar"
+      | Some _, _ ->
+        error_id id1 "duplicate declaration for grammar";
+    in
+    env.syms <- rebind "grammar" env.syms id1 (ps, t, Some gram')
+  | _ -> ()
 
 
 let populate_def env d' : Il.def =
@@ -1186,7 +1478,9 @@ let recursify_defs ds' : Il.def list =
 
 let elab ds : Il.script =
   let env = new_env () in
-  List.iter (infer_def env) ds;
+  List.iter (infer_syndef env) ds;
   let ds' = List.concat_map (elab_def env) ds in
   let ds' = List.map (populate_def env) ds' in
+  List.iter (infer_gramdef env) ds;
+  List.iter (elab_gramdef env) ds;
   recursify_defs ds'

--- a/spectec/src/frontend/elab.mli
+++ b/spectec/src/frontend/elab.mli
@@ -1,1 +1,3 @@
 val elab : El.Ast.script -> Il.Ast.script (* raises Source.Error *)
+
+val exp_of_sym : El.Ast.sym -> El.Ast.exp (* raises Source.Error *)

--- a/spectec/src/frontend/lexer.mll
+++ b/spectec/src/frontend/lexer.mll
@@ -128,15 +128,8 @@ rule after_nl = parse
 and after_nl_nl = parse
   | indent* "|"[' ''\t'] { NL_BAR }
   | indent* "--" { NL_NL_DASH }
-  | indent* '\n' { Lexing.new_line lexbuf; after_nl_nl_nl lexbuf }
-  | indent* line_comment '\n' { Lexing.new_line lexbuf; after_nl_nl_nl lexbuf }
-  | "" { token lexbuf }
-
-and after_nl_nl_nl = parse
-  | indent* "|"[' ''\t'] { NL_BAR }
-  | indent* "--" { NL_NL_DASH }
   | indent* '\n' { Lexing.new_line lexbuf; NL_NL_NL }
-  | indent* line_comment '\n' { Lexing.new_line lexbuf; after_nl_nl_nl lexbuf }
+  | indent* line_comment '\n' { Lexing.new_line lexbuf; after_nl_nl lexbuf }
   | "" { token lexbuf }
 
 and token = parse
@@ -153,6 +146,7 @@ and token = parse
   | ".." { DOTDOT }
   | "..." { DOTDOTDOT }
   | "|" { BAR }
+  | "||" { BARBAR }
   | "--" { DASH }
 
   | "," indent* line_comment? '\n' { Lexing.new_line lexbuf; COMMA_NL }
@@ -214,9 +208,13 @@ and token = parse
 
   | "bool" { BOOL }
   | "nat" { NAT }
+  | "int" { INT }
+  | "rat" { RAT }
+  | "real" { REAL }
   | "text" { TEXT }
 
   | "syntax" { SYNTAX }
+  | "grammar" { GRAMMAR }
   | "relation" { RELATION }
   | "rule" { RULE }
   | "var" { VAR }
@@ -224,7 +222,7 @@ and token = parse
 
   | "if" { IF }
   | "otherwise" { OTHERWISE }
-  | "hint" { HINT }
+  | "hint(" { HINT_LPAR }
 
   | "epsilon" { EPSILON }
   | "true" { BOOLLIT true }
@@ -242,6 +240,8 @@ and token = parse
 
   | upid as s { if is_var s then LOID s else UPID s }
   | loid as s { LOID s }
+  | (upid as s) "(" { if is_var s then LOID_LPAR s else UPID_LPAR s }
+  | (loid as s) "(" { LOID_LPAR s }
   | "."(id as s) { DOTID s }
 
   | ";;"utf8_no_nl*eof { EOF }

--- a/spectec/src/frontend/multiplicity.ml
+++ b/spectec/src/frontend/multiplicity.ml
@@ -80,7 +80,7 @@ and check_typ env ctx t =
   match t.it with
   | VarT id -> check_id env ctx id
   | BoolT
-  | NatT
+  | NumT _
   | TextT
   | AtomT _ -> ()
   | ParenT t1
@@ -118,6 +118,7 @@ and check_exp env ctx e =
   | HexE _
   | CharE _
   | TextE _
+  | SizeE _
   | EpsE
   | HoleE _
   | FuseE _ -> ()
@@ -175,7 +176,7 @@ and check_prem env ctx prem =
 
 let check_def d : env =
   match d.it with
-  | SynD _ | RelD _ | VarD _ | DecD _ | SepD | HintD _ -> Env.empty
+  | SynD _ | GramD _ | RelD _ | VarD _ | DecD _ | SepD | HintD _ -> Env.empty
   | RuleD (_id1, _id2, e, prems) ->
     let env = ref Env.empty in
     check_exp env [] e;

--- a/spectec/src/il/ast.ml
+++ b/spectec/src/il/ast.ml
@@ -54,11 +54,17 @@ type iter =
 
 (* Types *)
 
+and numtyp =
+  | NatT                         (* `nat` *)
+  | IntT                         (* `int` *)
+  | RatT                         (* `rat` *)
+  | RealT                        (* `real` *)
+
 and typ = typ' phrase
 and typ' =
   | VarT of id                   (* varid *)
   | BoolT                        (* `bool` *)
-  | NatT                         (* `nat` *)
+  | NumT of numtyp               (* numtyp *)
   | TextT                        (* `text` *)
   | TupT of typ list             (* typ * ... * typ *)
   | IterT of typ * iter          (* typ iter *)
@@ -77,28 +83,28 @@ and typcase = atom * (binds * typ * premise list) * hint list    (* variant case
 (* Expressions *)
 
 and unop =
-  | NotOp   (* `~` *)
-  | PlusOp  (* `+` *)
-  | MinusOp (* `-` *)
+  | NotOp             (* `~` *)
+  | PlusOp of numtyp  (* `+` *)
+  | MinusOp of numtyp (* `-` *)
 
 and binop =
-  | AndOp  (* `/\` *)
-  | OrOp   (* `\/` *)
-  | ImplOp (* `=>` *)
-  | EquivOp (* `<=>` *)
-  | AddOp  (* `+` *)
-  | SubOp  (* `-` *)
-  | MulOp  (* `*` *)
-  | DivOp  (* `/` *)
-  | ExpOp  (* `^` *)
+  | AndOp            (* `/\` *)
+  | OrOp             (* `\/` *)
+  | ImplOp           (* `=>` *)
+  | EquivOp          (* `<=>` *)
+  | AddOp of numtyp  (* `+` *)
+  | SubOp of numtyp  (* `-` *)
+  | MulOp of numtyp  (* `*` *)
+  | DivOp of numtyp  (* `/` *)
+  | ExpOp of numtyp  (* `^` *)
 
 and cmpop =
-  | EqOp (* `=` *)
-  | NeOp (* `=/=` *)
-  | LtOp (* `<` *)
-  | GtOp (* `>` *)
-  | LeOp (* `<=` *)
-  | GeOp (* `>=` *)
+  | EqOp             (* `=` *)
+  | NeOp             (* `=/=` *)
+  | LtOp of numtyp   (* `<` *)
+  | GtOp of numtyp   (* `>` *)
+  | LeOp of numtyp   (* `<=` *)
+  | GeOp of numtyp   (* `>=` *)
 
 and exp = (exp', typ) note_phrase
 and exp' =

--- a/spectec/src/il/free.ml
+++ b/spectec/src/il/free.ml
@@ -63,7 +63,7 @@ let rec free_iter iter =
 and free_typ t =
   match t.it with
   | VarT id -> free_synid id
-  | BoolT | NatT | TextT -> empty
+  | BoolT | NumT _ | TextT -> empty
   | TupT ts -> free_list free_typ ts
   | IterT (t1, iter) -> union (free_typ t1) (free_iter iter)
 

--- a/spectec/src/il/print.ml
+++ b/spectec/src/il/print.ml
@@ -44,27 +44,27 @@ let string_of_atom = function
 
 let string_of_unop = function
   | NotOp -> "~"
-  | PlusOp -> "+"
-  | MinusOp -> "-"
+  | PlusOp _ -> "+"
+  | MinusOp _ -> "-"
 
 let string_of_binop = function
   | AndOp -> "/\\"
   | OrOp -> "\\/"
   | ImplOp -> "=>"
   | EquivOp -> "<=>"
-  | AddOp -> "+"
-  | SubOp -> "-"
-  | MulOp -> "*"
-  | DivOp -> "/"
-  | ExpOp -> "^"
+  | AddOp _ -> "+"
+  | SubOp _ -> "-"
+  | MulOp _ -> "*"
+  | DivOp _ -> "/"
+  | ExpOp _ -> "^"
 
 let string_of_cmpop = function
   | EqOp -> "="
   | NeOp -> "=/="
-  | LtOp -> "<"
-  | GtOp -> ">"
-  | LeOp -> "<="
-  | GeOp -> ">="
+  | LtOp _ -> "<"
+  | GtOp _ -> ">"
+  | LeOp _ -> "<="
+  | GeOp _ -> ">="
 
 let string_of_mixop = function
   | [Atom a]::tail when List.for_all ((=) []) tail -> a
@@ -88,11 +88,18 @@ let rec string_of_iter iter =
   | ListN (e, Some id) ->
     "^(" ^ id.it ^ "<" ^ string_of_exp e ^ ")"
 
+and string_of_numtyp t =
+  match t with
+  | NatT -> "nat"
+  | IntT -> "int"
+  | RatT -> "rat"
+  | RealT -> "real"
+
 and string_of_typ t =
   match t.it with
   | VarT id -> id.it
   | BoolT -> "bool"
-  | NatT -> "nat"
+  | NumT t -> string_of_numtyp t
   | TextT -> "text"
   | TupT ts -> "(" ^ string_of_typs ", " ts ^ ")"
   | IterT (t1, iter) -> string_of_typ t1 ^ string_of_iter iter

--- a/spectec/src/middlend/sideconditions.ml
+++ b/spectec/src/middlend/sideconditions.ml
@@ -23,7 +23,7 @@ module Env = Map.Make(String)
 (* Smart constructor for LenE that optimizes |x^n| into n *)
 let lenE e = match e.it with
 | IterE (_, (ListN (ne, _), _)) -> ne
-| _ -> LenE e $$ e.at % (NatT $ e.at)
+| _ -> LenE e $$ e.at % (NumT NatT $ e.at)
 
 let is_null e = CmpE (EqOp, e, OptE None $$ e.at % e.note) $$ e.at % (BoolT $ e.at)
 let iffE e1 e2 = IfPr (BinE (EquivOp, e1, e2) $$ e1.at % (BoolT $ e1.at)) $ e1.at
@@ -64,7 +64,7 @@ let rec t_exp env e : premise list =
   (* First the conditions to be generated here *)
   begin match e.it with
   | IdxE (exp1, exp2) ->
-    [IfPr (CmpE (LtOp, exp2, LenE exp1 $$ e.at % exp2.note) $$ e.at % (BoolT $ e.at)) $ e.at]
+    [IfPr (CmpE (LtOp NatT, exp2, LenE exp1 $$ e.at % exp2.note) $$ e.at % (BoolT $ e.at)) $ e.at]
   | TheE exp ->
     [IfPr (CmpE (NeOp, exp, OptE None $$ e.at % exp.note) $$ e.at % (BoolT $ e.at)) $ e.at]
   | IterE (_exp, iterexp) -> iter_side_conditions env iterexp

--- a/spectec/test-latex/Makefile
+++ b/spectec/test-latex/Makefile
@@ -28,7 +28,7 @@ $(GENNAME).tex: $(SPECFILES) $(EXE)
 
 gen: $(GENNAME).tex
 
-latex-gen: $(GENOUTNAME).tex gen
+latex-gen: $(GENOUTNAME).tex $(EXE) gen
 	pdflatex $<
 
 

--- a/spectec/test-latex/spec-sphinx-in.rst
+++ b/spectec/test-latex/spec-sphinx-in.rst
@@ -55,6 +55,6 @@ $${definition: {funcaddr funcinst} {func table}}
 
 $${rule: Step/pure Step/read}
 
-$${rule+: {Step_pure/block Step_pure/loop} {Step_pure/if-*}}
+$${rule+: {Step_read/block Step_read/loop} {Step_pure/if-*}}
 
 $${rule+: Step_pure/if-*}

--- a/spectec/test-latex/spec-splice-in.tex
+++ b/spectec/test-latex/spec-splice-in.tex
@@ -74,7 +74,7 @@ An instruction sequence @@{:instr*} is well-typed with an instruction type @@{: 
 
 @@@{rule: Step/pure Step/read}
 
-@@@{rule+: {Step_pure/block Step_pure/loop} {Step_pure/if-*}}
+@@@{rule+: {Step_read/block Step_read/loop} {Step_pure/if-*}}
 
 @@@{rule+: Step_pure/if-*}
 


### PR DESCRIPTION
This PR implements a `grammar` definition construct and specifies Wasm's binary grammars. See Language.md and spec for details. For now, grammars are simply erased when elaborating into the IL, I doubt we'll do something smart with them anytime soon.

However, this required another extension to the DSL:

* Integers. While at it, and in order to deal with floats later, I generalised numbers to a hierarchy nat<int<rat<real. Subsumption is explicit in the IL using SubE (could also introduce a separate expression form if folks prefer).

* As a consequence, Overloading. Required a rewrite of expression elaboration to a more properly bidirectional approach. In the IL, numeric operators are now annotated with their type.

Spec'ing the binary format also required tweaking and fixing some corners I had previously cut in the spec itself:

* Introduction of type indices and corresponding rules (previously we had inlined all function types).

* Introduction of block types (previously just were an inlined function type as well).

* Refined abstract syntax of load/stores to use memop.

* Fixing the abstract syntax of SELECT.
