### PR TITLE
Add signature for alloctypes

### DIFF
--- a/spectec/spec/9-module.watsup
+++ b/spectec/spec/9-module.watsup
@@ -4,6 +4,8 @@
 
 ;; Definitions
 
+def $alloctypes(rectype*) : deftype*
+
 def $allocfunc(store, moduleinst, func) : (store, funcaddr)
 def $allocfunc(s, mm, func) = (s[.FUNC =.. fi], |s.FUNC|)
   -- if func = FUNC x local* expr
@@ -101,7 +103,7 @@ def $allocmodule(s, module, externval*, val_g*, ref_t*, (ref_e*)*) = (s_6, mm)
   -- if da* = $(|s.DATA|+i_d)^(i_d<n_d)
   -- if xi* = $instexport(fa_ex* fa*, ga_ex* ga*, ta_ex* ta*, ma_ex* ma*, export)*
   -- if mm = {
-      TYPE dt*,
+      TYPE $alloctypes(rectype*),
       FUNC fa_ex* fa*,
       GLOBAL ga_ex* ga*,
       TABLE ta_ex* ta*,


### PR DESCRIPTION
Hello,
I am currently working on converting the DSL you wrote in wasm3 into AL to demonstrate the generality of the SpecTec approach. Fortunately, most of them seem to be converted well with just a few minor adjustments. However, one part that isn't converted properly is the `allocmodule`, as there is no allocation for the type of module instance. Fortunately, just defining the signature of the `alloctypes` function was enough to successfully complete the conversion of `allocmodule.` Now, I'm trying to define the body of the `alloctypes` function. But there is a typo in the gc proposal, making it hard to comprehend, and it is defined differently in function reference proposal. So, I'm having difficulty understanding how `alloctype*` should be defined. Could you please provide some guidance on the definition?


<img width="692" alt="Screenshot 2023-10-30 at 2 51 18 PM" src="https://github.com/Wasm-DSL/spectec/assets/50018375/bfcd4fa7-66da-4243-ab73-128c0adce0e0">

* allocating type in gc proposal
<img width="367" alt="Screenshot 2023-10-30 at 2 57 36 PM" src="https://github.com/Wasm-DSL/spectec/assets/50018375/3ba32227-3c59-4797-ad3b-efa2a8e06703">

* allocating type in function reference proposal

(Perhaps 'alloctypes' is not a critical component for execution. If that's the case, please kindly inform me, and we can postpone its body.)