### PR TITLE
Fix reduction rule of `CALL`

### DIFF
--- a/spectec/spec/4-runtime.watsup
+++ b/spectec/spec/4-runtime.watsup
@@ -159,7 +159,7 @@ var z : state
 syntax admininstr hint(show instr) hint(desc "administrative instruction") =
   | instr
   | addrref
-  | CALL_ADDR funcaddr             hint(show CALL %)
+  | CALL_ADDR funcaddr             hint(show INVOKE %)
   | LABEL_ n `{instr*} admininstr* hint(show LABEL_%#% %%)
   | FRAME_ n `{frame} admininstr*  hint(show FRAME_%#% %%)
   | TRAP

--- a/spectec/spec/4-runtime.watsup
+++ b/spectec/spec/4-runtime.watsup
@@ -159,6 +159,7 @@ var z : state
 syntax admininstr hint(show instr) hint(desc "administrative instruction") =
   | instr
   | addrref
+  | CALL_ADDR funcaddr             hint(show CALL %)
   | LABEL_ n `{instr*} admininstr* hint(show LABEL_%#% %%)
   | FRAME_ n `{frame} admininstr*  hint(show FRAME_%#% %%)
   | TRAP

--- a/spectec/spec/8-reduction.watsup
+++ b/spectec/spec/8-reduction.watsup
@@ -150,17 +150,13 @@ rule Step_read/br_on_cast_fail-fail:
 ;; Function instructions
 
 rule Step_read/call:
-  z; (CALL x)  ~>  (CALL_REF $funcaddr(z)[x])
+  z; (CALL x)  ~>  (CALL_ADDR $funcaddr(z)[x])
 
 rule Step_read/call_ref-null:
   z; (REF.NULL ht) (CALL_REF x)  ~>  TRAP
 
 rule Step_read/call_ref-func:
-  z; val^n (REF.FUNC_ADDR a) (CALL_REF x)  ~>  (FRAME_ m `{f} (LABEL_ m `{epsilon} instr*))
-  -- if $funcinst(z)[a] = fi
-  -- Expand: fi.TYPE ~~ FUNC (t_1^n -> t_2^m)
-  -- if fi.CODE = FUNC x (LOCAL t)* (instr*)
-  -- if f = {LOCAL val^n ($default(t))*, MODULE fi.MODULE}
+  z; val^n (REF.FUNC_ADDR a) (CALL_REF x)  ~> (CALL_ADDR a) 
 
 
 rule Step_read/return_call:
@@ -180,6 +176,14 @@ rule Step_pure/call_indirect-call:
 
 rule Step_pure/return_call_indirect:
   (RETURN_CALL_INDIRECT x y)  ~>  (TABLE.GET x) (REF.CAST (REF NULL $idx(y))) (RETURN_CALL_REF y)
+
+
+rule Step_read/call_addr:
+  z; val^n (CALL_ADDR a)  ~>  (FRAME_ m `{f} (LABEL_ m `{epsilon} instr*))
+  -- if $funcinst(z)[a] = fi
+  -- Expand: fi.TYPE ~~ FUNC (t_1^n -> t_2^m)
+  -- if fi.CODE = FUNC x (LOCAL t)* (instr*)
+  -- if f = {LOCAL val^n ($default(t))*, MODULE fi.MODULE}
 
 
 rule Step_pure/frame-vals:

--- a/spectec/spec/8-reduction.watsup
+++ b/spectec/spec/8-reduction.watsup
@@ -156,7 +156,7 @@ rule Step_read/call_ref-null:
   z; (REF.NULL ht) (CALL_REF x)  ~>  TRAP
 
 rule Step_read/call_ref-func:
-  z; val^n (REF.FUNC_ADDR a) (CALL_REF x)  ~> (CALL_ADDR a) 
+  z; (REF.FUNC_ADDR a) (CALL_REF x)  ~> (CALL_ADDR a) 
 
 
 rule Step_read/return_call:


### PR DESCRIPTION
Hi, I have spotted one meta-level type error in the below reduction rule of the `CALL` instruction.

```
rule Step_read/call:
  z; (CALL x)  ~>  (CALL_REF $funcaddr(z)[x])
```

`CALL` takes `funcidx` as parameter, while `CALL_REF` takes `typeidx` as parameter.

In the rule, `$funcaddr(z)[x]` has type `funcaddr`, not `typeidx`. So the reduction rule ends up calling function with "type index" `$funcaddr(z)[x]`, as opposed to the intention of calling by "address".

I suppose it somehow passed elaboration since both `funcaddr` and `typeidx` are modeled as `nat` in our DSL.

So I propose re-introducing the `CALL_ADDR` admin instruction in the main branch as follows.
It follows the reduction rules in the [Function Reference Types Proposal](https://github.com/WebAssembly/function-references/tree/main).

```
rule Step_read/call:
  z; (CALL x)  ~>  (CALL_ADDR $funcaddr(z)[x])

rule Step_read/call_ref-null:
  z; (REF.NULL ht) (CALL_REF x)  ~>  TRAP

rule Step_read/call_ref-func:
  z; (REF.FUNC_ADDR a) (CALL_REF x)  ~> (CALL_ADDR a) 

rule Step_read/call_addr:
  z; val^n (CALL_ADDR a)  ~>  (FRAME_ m `{f} (LABEL_ m `{epsilon} instr*))
  -- if $funcinst(z)[a] = fi
  -- Expand: fi.TYPE ~~ FUNC (t_1^n -> t_2^m)
  -- if fi.CODE = FUNC x (LOCAL t)* (instr*)
  -- if f = {LOCAL val^n ($default(t))*, MODULE fi.MODULE}
```

`CALL_ADDR` takes the responsibility of actual function call (pushing the frame), which was previously in the reduction rule of `CALL_REF`.
Both `CALL` and `CALL_REF` reduces to `CALL_ADDR`.



