### PR TITLE
Fix reduction rules of `CALL` and `RETURN_CALL`

### DIFF
--- a/spectec/spec/1-syntax.watsup
+++ b/spectec/spec/1-syntax.watsup
@@ -285,11 +285,11 @@ syntax instr/control hint(desc "control instruction") =
   | BR_ON_CAST labelidx reftype reftype
   | BR_ON_CAST_FAIL labelidx reftype reftype
   | CALL funcidx
-  | CALL_REF (typeidx)?
+  | CALL_REF typeidx?
   | CALL_INDIRECT tableidx typeidx
   | RETURN
   | RETURN_CALL funcidx
-  | RETURN_CALL_REF (typeidx)?
+  | RETURN_CALL_REF typeidx?
   | RETURN_CALL_INDIRECT tableidx typeidx
   | ...
 

--- a/spectec/spec/1-syntax.watsup
+++ b/spectec/spec/1-syntax.watsup
@@ -285,11 +285,11 @@ syntax instr/control hint(desc "control instruction") =
   | BR_ON_CAST labelidx reftype reftype
   | BR_ON_CAST_FAIL labelidx reftype reftype
   | CALL funcidx
-  | CALL_REF typeidx
+  | CALL_REF (typeidx)?
   | CALL_INDIRECT tableidx typeidx
   | RETURN
   | RETURN_CALL funcidx
-  | RETURN_CALL_REF typeidx
+  | RETURN_CALL_REF (typeidx)?
   | RETURN_CALL_INDIRECT tableidx typeidx
   | ...
 

--- a/spectec/spec/6-typing.watsup
+++ b/spectec/spec/6-typing.watsup
@@ -645,7 +645,7 @@ rule Instr_ok/call:
   -- Expand: C.FUNC[x] ~~ FUNC (t_1* -> t_2*)
 
 rule Instr_ok/call_ref:
-  C |- CALL_REF x? : t_1* (REF NULL $idx(x)) -> t_2*
+  C |- CALL_REF x : t_1* (REF NULL $idx(x)) -> t_2*
   -- Expand: C.TYPE[x] ~~ FUNC (t_1* -> t_2*)
 
 rule Instr_ok/call_indirect:
@@ -661,7 +661,7 @@ rule Instr_ok/return_call:
   -- Resulttype_sub: C |- t_2* <: t'_2*
 
 rule Instr_ok/return_call_ref:
-  C |- RETURN_CALL_REF x? : t_3* t_1* (REF NULL $idx(x)) -> t_4*
+  C |- RETURN_CALL_REF x : t_3* t_1* (REF NULL $idx(x)) -> t_4*
   -- Expand: C.TYPE[x] ~~ FUNC (t_1* -> t_2*)
   -- if C.RETURN = (t'_2*)
   -- Resulttype_sub: C |- t_2* <: t'_2*

--- a/spectec/spec/6-typing.watsup
+++ b/spectec/spec/6-typing.watsup
@@ -645,7 +645,7 @@ rule Instr_ok/call:
   -- Expand: C.FUNC[x] ~~ FUNC (t_1* -> t_2*)
 
 rule Instr_ok/call_ref:
-  C |- CALL_REF x : t_1* (REF NULL $idx(x)) -> t_2*
+  C |- CALL_REF x? : t_1* (REF NULL $idx(x)) -> t_2*
   -- Expand: C.TYPE[x] ~~ FUNC (t_1* -> t_2*)
 
 rule Instr_ok/call_indirect:
@@ -661,7 +661,7 @@ rule Instr_ok/return_call:
   -- Resulttype_sub: C |- t_2* <: t'_2*
 
 rule Instr_ok/return_call_ref:
-  C |- RETURN_CALL_REF x : t_3* t_1* (REF NULL $idx(x)) -> t_4*
+  C |- RETURN_CALL_REF x? : t_3* t_1* (REF NULL $idx(x)) -> t_4*
   -- Expand: C.TYPE[x] ~~ FUNC (t_1* -> t_2*)
   -- if C.RETURN = (t'_2*)
   -- Resulttype_sub: C |- t_2* <: t'_2*

--- a/spectec/spec/8-reduction.watsup
+++ b/spectec/spec/8-reduction.watsup
@@ -155,7 +155,7 @@ rule Step_read/br_on_cast_fail-fail:
 ;; Function instructions
 
 rule Step_read/call:
-  z; (CALL x)  ~>  (CALL_REF $funcaddr(z)[x])
+  z; (CALL x)  ~>  (REF.FUNC_ADDR $funcaddr(z)[x]) (CALL_REF)
 
 rule Step_read/call_ref-null:
   z; (REF.NULL ht) (CALL_REF x)  ~>  TRAP
@@ -169,7 +169,7 @@ rule Step_read/call_ref-func:
 
 
 rule Step_read/return_call:
-  z; (RETURN_CALL x)  ~>  (RETURN_CALL_REF $funcaddr(z)[x])
+  z; (RETURN_CALL x)  ~>  (REF.FUNC_ADDR $funcaddr(z)[x]) (RETURN_CALL_REF)
 
 rule Step_read/return_call_ref-frame:
   z; (FRAME_ k `{f} val'* val^n ref (RETURN_CALL_REF x) instr*)  ~>  val^n ref (CALL_REF x)

--- a/spectec/test-frontend/TEST.md
+++ b/spectec/test-frontend/TEST.md
@@ -457,11 +457,11 @@ syntax instr =
   | BR_ON_CAST(labelidx, reftype, reftype)
   | BR_ON_CAST_FAIL(labelidx, reftype, reftype)
   | CALL(funcidx)
-  | CALL_REF(typeidx)
+  | CALL_REF(typeidx?)
   | CALL_INDIRECT(tableidx, typeidx)
   | RETURN
   | RETURN_CALL(funcidx)
-  | RETURN_CALL_REF(typeidx)
+  | RETURN_CALL_REF(typeidx?)
   | RETURN_CALL_INDIRECT(tableidx, typeidx)
   | CONST(numtype, c_numtype)
   | UNOP(numtype, unop_numtype)
@@ -1180,11 +1180,11 @@ syntax admininstr =
   | BR_ON_CAST(labelidx, reftype, reftype)
   | BR_ON_CAST_FAIL(labelidx, reftype, reftype)
   | CALL(funcidx)
-  | CALL_REF(typeidx)
+  | CALL_REF(typeidx?)
   | CALL_INDIRECT(tableidx, typeidx)
   | RETURN
   | RETURN_CALL(funcidx)
-  | RETURN_CALL_REF(typeidx)
+  | RETURN_CALL_REF(typeidx?)
   | RETURN_CALL_INDIRECT(tableidx, typeidx)
   | CONST(numtype, c_numtype)
   | UNOP(numtype, unop_numtype)
@@ -2239,7 +2239,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
 
   ;; 6-typing.watsup:647.1-649.46
   rule call_ref {C : context, t_1* : valtype*, t_2* : valtype*, x : idx}:
-    `%|-%:%`(C, CALL_REF_instr(x), `%->%`(t_1*{t_1} :: [REF_valtype(`NULL%?`(?(())), ($idx(x) <: heaptype))], t_2*{t_2}))
+    `%|-%:%`(C, CALL_REF_instr(?(x)), `%->%`(t_1*{t_1} :: [REF_valtype(`NULL%?`(?(())), ($idx(x) <: heaptype))], t_2*{t_2}))
     -- Expand: `%~~%`(C.TYPE_context[x], FUNC_comptype(`%->%`(t_1*{t_1}, t_2*{t_2})))
 
   ;; 6-typing.watsup:651.1-655.46
@@ -2258,7 +2258,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
 
   ;; 6-typing.watsup:663.1-667.40
   rule return_call_ref {C : context, t'_2* : valtype*, t_1* : valtype*, t_2* : valtype*, t_3* : valtype*, t_4* : valtype*, x : idx}:
-    `%|-%:%`(C, RETURN_CALL_REF_instr(x), `%->%`(t_3*{t_3} :: t_1*{t_1} :: [REF_valtype(`NULL%?`(?(())), ($idx(x) <: heaptype))], t_4*{t_4}))
+    `%|-%:%`(C, RETURN_CALL_REF_instr(?(x)), `%->%`(t_3*{t_3} :: t_1*{t_1} :: [REF_valtype(`NULL%?`(?(())), ($idx(x) <: heaptype))], t_4*{t_4}))
     -- Expand: `%~~%`(C.TYPE_context[x], FUNC_comptype(`%->%`(t_1*{t_1}, t_2*{t_2})))
     -- if (C.RETURN_context = ?(t'_2*{t'_2}))
     -- Resulttype_sub: `%|-%*<:%*`(C, t_2*{t_2}, t'_2*{t'_2})
@@ -2994,11 +2994,11 @@ relation Step_pure: `%*~>%*`(admininstr*, admininstr*)
 
   ;; 8-reduction.watsup:183.1-184.84
   rule call_indirect-call {x : idx, y : idx}:
-    `%*~>%*`([CALL_INDIRECT_admininstr(x, y)], [TABLE.GET_admininstr(x) REF.CAST_admininstr(REF_reftype(`NULL%?`(?(())), ($idx(y) <: heaptype))) CALL_REF_admininstr(y)])
+    `%*~>%*`([CALL_INDIRECT_admininstr(x, y)], [TABLE.GET_admininstr(x) REF.CAST_admininstr(REF_reftype(`NULL%?`(?(())), ($idx(y) <: heaptype))) CALL_REF_admininstr(?(y))])
 
   ;; 8-reduction.watsup:186.1-187.98
   rule return_call_indirect {x : idx, y : idx}:
-    `%*~>%*`([RETURN_CALL_INDIRECT_admininstr(x, y)], [TABLE.GET_admininstr(x) REF.CAST_admininstr(REF_reftype(`NULL%?`(?(())), ($idx(y) <: heaptype))) RETURN_CALL_REF_admininstr(y)])
+    `%*~>%*`([RETURN_CALL_INDIRECT_admininstr(x, y)], [TABLE.GET_admininstr(x) REF.CAST_admininstr(REF_reftype(`NULL%?`(?(())), ($idx(y) <: heaptype))) RETURN_CALL_REF_admininstr(?(y))])
 
   ;; 8-reduction.watsup:190.1-191.35
   rule frame-vals {f : frame, n : n, val^n : val^n}:
@@ -3168,34 +3168,34 @@ relation Step_read: `%~>%*`(config, admininstr*)
     `%~>%*`(`%;%*`(z, [(ref <: admininstr) BR_ON_CAST_FAIL_admininstr(l, rt_1, rt_2)]), [(ref <: admininstr) BR_admininstr(l)])
     -- otherwise
 
-  ;; 8-reduction.watsup:157.1-158.46
+  ;; 8-reduction.watsup:157.1-158.62
   rule call {x : idx, z : state}:
-    `%~>%*`(`%;%*`(z, [CALL_admininstr(x)]), [CALL_REF_admininstr($funcaddr(z)[x])])
+    `%~>%*`(`%;%*`(z, [CALL_admininstr(x)]), [REF.FUNC_ADDR_admininstr($funcaddr(z)[x]) CALL_REF_admininstr(?())])
 
   ;; 8-reduction.watsup:160.1-161.42
   rule call_ref-null {ht : heaptype, x : idx, z : state}:
-    `%~>%*`(`%;%*`(z, [REF.NULL_admininstr(ht) CALL_REF_admininstr(x)]), [TRAP_admininstr])
+    `%~>%*`(`%;%*`(z, [REF.NULL_admininstr(ht) CALL_REF_admininstr(?(x))]), [TRAP_admininstr])
 
   ;; 8-reduction.watsup:163.1-168.59
   rule call_ref-func {a : addr, f : frame, fi : funcinst, instr* : instr*, m : m, n : n, t* : valtype*, t_1^n : valtype^n, t_2^m : valtype^m, val^n : val^n, x : idx, z : state}:
-    `%~>%*`(`%;%*`(z, (val <: admininstr)^n{val} :: [REF.FUNC_ADDR_admininstr(a) CALL_REF_admininstr(x)]), [FRAME__admininstr(m, f, [LABEL__admininstr(m, [], (instr <: admininstr)*{instr})])])
+    `%~>%*`(`%;%*`(z, (val <: admininstr)^n{val} :: [REF.FUNC_ADDR_admininstr(a) CALL_REF_admininstr(?(x))]), [FRAME__admininstr(m, f, [LABEL__admininstr(m, [], (instr <: admininstr)*{instr})])])
     -- if ($funcinst(z)[a] = fi)
     -- Expand: `%~~%`(fi.TYPE_funcinst, FUNC_comptype(`%->%`(t_1^n{t_1}, t_2^m{t_2})))
     -- if (fi.CODE_funcinst = `FUNC%%*%`(x, LOCAL(t)*{t}, instr*{instr}))
     -- if (f = {LOCAL ?(val)^n{val} :: $default(t)*{t}, MODULE fi.MODULE_funcinst})
 
-  ;; 8-reduction.watsup:171.1-172.60
+  ;; 8-reduction.watsup:171.1-172.76
   rule return_call {x : idx, z : state}:
-    `%~>%*`(`%;%*`(z, [RETURN_CALL_admininstr(x)]), [RETURN_CALL_REF_admininstr($funcaddr(z)[x])])
+    `%~>%*`(`%;%*`(z, [RETURN_CALL_admininstr(x)]), [REF.FUNC_ADDR_admininstr($funcaddr(z)[x]) RETURN_CALL_REF_admininstr(?())])
 
   ;; 8-reduction.watsup:174.1-176.59
   rule return_call_ref-frame {a : addr, f : frame, instr* : instr*, k : nat, m : m, n : n, ref : ref, t_1^n : valtype^n, t_2^m : valtype^m, val^n : val^n, val'* : val*, x : idx, z : state}:
-    `%~>%*`(`%;%*`(z, [FRAME__admininstr(k, f, (val' <: admininstr)*{val'} :: (val <: admininstr)^n{val} :: [(ref <: admininstr)] :: [RETURN_CALL_REF_admininstr(x)] :: (instr <: admininstr)*{instr})]), (val <: admininstr)^n{val} :: [(ref <: admininstr) CALL_REF_admininstr(x)])
+    `%~>%*`(`%;%*`(z, [FRAME__admininstr(k, f, (val' <: admininstr)*{val'} :: (val <: admininstr)^n{val} :: [(ref <: admininstr)] :: [RETURN_CALL_REF_admininstr(?(x))] :: (instr <: admininstr)*{instr})]), (val <: admininstr)^n{val} :: [(ref <: admininstr) CALL_REF_admininstr(?(x))])
     -- Expand: `%~~%`($funcinst(z)[a].TYPE_funcinst, FUNC_comptype(`%->%`(t_1^n{t_1}, t_2^m{t_2})))
 
   ;; 8-reduction.watsup:178.1-180.59
   rule return_call_ref-label {a : addr, instr* : instr*, instr'* : instr*, k : nat, m : m, n : n, ref : ref, t_1^n : valtype^n, t_2^m : valtype^m, val^n : val^n, val'* : val*, x : idx, z : state}:
-    `%~>%*`(`%;%*`(z, [LABEL__admininstr(k, instr'*{instr'}, (val' <: admininstr)*{val'} :: (val <: admininstr)^n{val} :: [(ref <: admininstr)] :: [RETURN_CALL_REF_admininstr(x)] :: (instr <: admininstr)*{instr})]), (val <: admininstr)^n{val} :: [(ref <: admininstr) RETURN_CALL_REF_admininstr(x)])
+    `%~>%*`(`%;%*`(z, [LABEL__admininstr(k, instr'*{instr'}, (val' <: admininstr)*{val'} :: (val <: admininstr)^n{val} :: [(ref <: admininstr)] :: [RETURN_CALL_REF_admininstr(?(x))] :: (instr <: admininstr)*{instr})]), (val <: admininstr)^n{val} :: [(ref <: admininstr) RETURN_CALL_REF_admininstr(?(x))])
     -- Expand: `%~~%`($funcinst(z)[a].TYPE_funcinst, FUNC_comptype(`%->%`(t_1^n{t_1}, t_2^m{t_2})))
 
   ;; 8-reduction.watsup:244.1-245.55
@@ -3920,7 +3920,7 @@ def instantiate : (store, module, externval*) -> config
 ;; 9-module.watsup:181.1-181.44
 def invoke : (store, funcaddr, val*) -> config
   ;; 9-module.watsup:182.1-195.53
-  def {expr : expr, f : frame, fa : funcaddr, local* : local*, mm : moduleinst, n : n, s : store, t_1^n : valtype^n, t_2* : valtype*, val^n : val^n, x : idx} invoke(s, fa, val^n{val}) = `%;%*`(`%;%`(s, f), (val <: admininstr)^n{val} :: [REF.FUNC_ADDR_admininstr(fa) CALL_REF_admininstr(0)])
+  def {expr : expr, f : frame, fa : funcaddr, local* : local*, mm : moduleinst, n : n, s : store, t_1^n : valtype^n, t_2* : valtype*, val^n : val^n, x : idx} invoke(s, fa, val^n{val}) = `%;%*`(`%;%`(s, f), (val <: admininstr)^n{val} :: [REF.FUNC_ADDR_admininstr(fa) CALL_REF_admininstr(?(0))])
     -- if (mm = {TYPE [s.FUNC_store[fa].TYPE_funcinst], FUNC [], GLOBAL [], TABLE [], MEM [], ELEM [], DATA [], EXPORT []})
     -- if (f = {LOCAL [], MODULE mm})
     -- if ($funcinst(`%;%`(s, f))[fa].CODE_funcinst = `FUNC%%*%`(x, local*{local}, expr))
@@ -4264,11 +4264,11 @@ $$
 \mathsf{br\_on\_cast}~{\mathit{labelidx}}~{\mathit{reftype}}~{\mathit{reftype}} \\ &&|&
 \mathsf{br\_on\_cast\_fail}~{\mathit{labelidx}}~{\mathit{reftype}}~{\mathit{reftype}} \\ &&|&
 \mathsf{call}~{\mathit{funcidx}} \\ &&|&
-\mathsf{call\_ref}~{\mathit{typeidx}} \\ &&|&
+\mathsf{call\_ref}~{{\mathit{typeidx}}^?} \\ &&|&
 \mathsf{call\_indirect}~{\mathit{tableidx}}~{\mathit{typeidx}} \\ &&|&
 \mathsf{return} \\ &&|&
 \mathsf{return\_call}~{\mathit{funcidx}} \\ &&|&
-\mathsf{return\_call\_ref}~{\mathit{typeidx}} \\ &&|&
+\mathsf{return\_call\_ref}~{{\mathit{typeidx}}^?} \\ &&|&
 \mathsf{return\_call\_indirect}~{\mathit{tableidx}}~{\mathit{typeidx}} \\ &&|&
 {\mathit{numtype}}.\mathsf{const}~{\mathit{c}}_{{\mathit{numtype}}} \\ &&|&
 {\mathit{numtype}} . {\mathit{unop}}_{{\mathit{numtype}}} \\ &&|&
@@ -8218,7 +8218,7 @@ $$
 
 $$
 \begin{array}{@{}l@{}lcl@{}l@{}}
-{[\textsc{\scriptsize E{-}call}]} \quad & {\mathit{z}} ; (\mathsf{call}~{\mathit{x}}) &\hookrightarrow& (\mathsf{call\_ref}~{\mathit{z}}.\mathsf{module}.\mathsf{func}[{\mathit{x}}]) &  \\
+{[\textsc{\scriptsize E{-}call}]} \quad & {\mathit{z}} ; (\mathsf{call}~{\mathit{x}}) &\hookrightarrow& (\mathsf{ref.func}~{\mathit{z}}.\mathsf{module}.\mathsf{func}[{\mathit{x}}])~(\mathsf{call\_ref}) &  \\
 {[\textsc{\scriptsize E{-}call\_ref{-}null}]} \quad & {\mathit{z}} ; (\mathsf{ref.null}~{\mathit{ht}})~(\mathsf{call\_ref}~{\mathit{x}}) &\hookrightarrow& \mathsf{trap} &  \\
 {[\textsc{\scriptsize E{-}call\_ref{-}func}]} \quad & {\mathit{z}} ; {{\mathit{val}}^{{\mathit{n}}}}~(\mathsf{ref.func}~{\mathit{a}})~(\mathsf{call\_ref}~{\mathit{x}}) &\hookrightarrow& ({{\mathsf{frame}}_{{\mathit{m}}}}{\{{\mathit{f}}\}}~({{\mathsf{label}}_{{\mathit{m}}}}{\{\epsilon\}}~{{\mathit{instr}}^\ast})) &\quad
   \mbox{if}~{\mathit{z}}.\mathsf{func}[{\mathit{a}}] = {\mathit{fi}} \\
@@ -8233,7 +8233,7 @@ $$
 
 $$
 \begin{array}{@{}l@{}lcl@{}l@{}}
-{[\textsc{\scriptsize E{-}return\_call}]} \quad & {\mathit{z}} ; (\mathsf{return\_call}~{\mathit{x}}) &\hookrightarrow& (\mathsf{return\_call\_ref}~{\mathit{z}}.\mathsf{module}.\mathsf{func}[{\mathit{x}}]) &  \\
+{[\textsc{\scriptsize E{-}return\_call}]} \quad & {\mathit{z}} ; (\mathsf{return\_call}~{\mathit{x}}) &\hookrightarrow& (\mathsf{ref.func}~{\mathit{z}}.\mathsf{module}.\mathsf{func}[{\mathit{x}}])~(\mathsf{return\_call\_ref}) &  \\
 {[\textsc{\scriptsize E{-}return\_call\_ref{-}frame}]} \quad & {\mathit{z}} ; ({{\mathsf{frame}}_{{\mathit{k}}}}{\{{\mathit{f}}\}}~{{\mathit{val}'}^\ast}~{{\mathit{val}}^{{\mathit{n}}}}~{\mathit{ref}}~(\mathsf{return\_call\_ref}~{\mathit{x}})~{{\mathit{instr}}^\ast}) &\hookrightarrow& {{\mathit{val}}^{{\mathit{n}}}}~{\mathit{ref}}~(\mathsf{call\_ref}~{\mathit{x}}) &\quad
   \mbox{if}~{\mathit{z}}.\mathsf{func}[{\mathit{a}}].\mathsf{type} \approx \mathsf{func}~({{\mathit{t}}_{{1}}^{{\mathit{n}}}} \rightarrow {{\mathit{t}}_{{2}}^{{\mathit{m}}}}) \\
 {[\textsc{\scriptsize E{-}return\_call\_ref{-}label}]} \quad & {\mathit{z}} ; ({{\mathsf{label}}_{{\mathit{k}}}}{\{{{\mathit{instr}'}^\ast}\}}~{{\mathit{val}'}^\ast}~{{\mathit{val}}^{{\mathit{n}}}}~{\mathit{ref}}~(\mathsf{return\_call\_ref}~{\mathit{x}})~{{\mathit{instr}}^\ast}) &\hookrightarrow& {{\mathit{val}}^{{\mathit{n}}}}~{\mathit{ref}}~(\mathsf{return\_call\_ref}~{\mathit{x}}) &\quad


### PR DESCRIPTION
From the alternative proposed in the previous [PR#41](https://github.com/Wasm-DSL/spectec/pull/41),

this fixes the reduction rules of `CALL` and `RETURN_CALL`.

Previously, each reduced to `CALL_REF` and `RETURN_CALL_REF` with `typeidx` set as `$funcaddr(z)[x]`.

Now each reduces to `CALL_REF` and `RETURN_CALL_REF` where `typeidx` is None, where the function address is pushed into the stack as `(REF.FUNC_ADDR $funcaddr(z)[x])`.

This includes changing the syntax of `CALL_REF` and `RETURN_CALL_REF` to have an optional `typeidx`.
