### PR TITLE
Fix dimension mismatch in reduction of `ARRAY.NEW_DATA`

### DIFF
--- a/spectec/spec/2-syntax-aux.watsup
+++ b/spectec/spec/2-syntax-aux.watsup
@@ -238,3 +238,11 @@ def $memsxt(externtype et*) = $memsxt(et*)  -- otherwise
 
 def $memop0 : memop  hint(show )
 def $memop0 = {ALIGN 0, OFFSET 0}
+
+;;
+;; Auxiliary definitions on Bytes
+;;
+
+def $concat_bytes(byte**) : byte*  hint(show $concat(%))
+def $concat_bytes(epsilon) = epsilon
+def $concat_bytes(b* b'**) = b* $concat_bytes(b'**)

--- a/spectec/spec/3-numerics.watsup
+++ b/spectec/spec/3-numerics.watsup
@@ -40,7 +40,7 @@ def $invibytes(N, b*) = n  -- if $ibytes(N, n) = b*
 def $invfbytes(N, b*) = p  -- if $fbytes(N, p) = b*
 
 def $group_bytes_by(nat, byte*): (byte*)*
-def $group_bytes_by(n, byte*) = (byte*[0:n]) $group_bytes_by(n, byte*[n:|byte*| - n])
+def $group_bytes_by(n, byte*) = (byte*[0 : n]) $group_bytes_by(n, byte*[n : |byte*| - n])
   -- if n >= |byte*|
 def $group_bytes_by(n, byte*) = epsilon
   -- otherwise

--- a/spectec/spec/3-numerics.watsup
+++ b/spectec/spec/3-numerics.watsup
@@ -38,3 +38,9 @@ def $invfbytes(N, byte*) : fN
 
 def $invibytes(N, b*) = n  -- if $ibytes(N, n) = b*
 def $invfbytes(N, b*) = p  -- if $fbytes(N, p) = b*
+
+def $group_bytes_by(nat, byte*): (byte*)*
+def $group_bytes_by(n, byte*) = (byte*[0:n]) $group_bytes_by(n, byte*[n:|byte*| - n])
+  -- if n >= |byte*|
+def $group_bytes_by(n, byte*) = epsilon
+  -- otherwise

--- a/spectec/spec/3-numerics.watsup
+++ b/spectec/spec/3-numerics.watsup
@@ -38,9 +38,3 @@ def $invfbytes(N, byte*) : fN
 
 def $invibytes(N, b*) = n  -- if $ibytes(N, n) = b*
 def $invfbytes(N, b*) = p  -- if $fbytes(N, p) = b*
-
-def $group_bytes_by(nat, byte*): (byte*)*
-def $group_bytes_by(n, byte*) = (byte*[0 : n]) $group_bytes_by(n, byte*[n : |byte*| - n])
-  -- if n >= |byte*|
-def $group_bytes_by(n, byte*) = epsilon
-  -- otherwise

--- a/spectec/spec/8-reduction.watsup
+++ b/spectec/spec/8-reduction.watsup
@@ -374,7 +374,7 @@ rule Step_read/array.new_data-alloc:
   z; (CONST I32 i) (CONST I32 n) (ARRAY.NEW_DATA x y)  ~>  (CONST nt c)^n (ARRAY.NEW_FIXED x n)
   -- Expand: $type(z, x) ~~ ARRAY (mut zt)
   -- if nt = $unpacknumtype(zt)
-  -- if $ztbytes(zt, c)^n = $group_bytes_by(n, $data(z, y).DATA[i : n * $storagesize(zt)/8])
+  -- if $concat_bytes($ztbytes(zt, c)^n) = $data(z, y).DATA[i : n * $storagesize(zt)/8]
 
 
 rule Step_read/array.get-null:

--- a/spectec/spec/8-reduction.watsup
+++ b/spectec/spec/8-reduction.watsup
@@ -374,7 +374,7 @@ rule Step_read/array.new_data-alloc:
   z; (CONST I32 i) (CONST I32 n) (ARRAY.NEW_DATA x y)  ~>  (CONST nt c)^n (ARRAY.NEW_FIXED x n)
   -- Expand: $type(z, x) ~~ ARRAY (mut zt)
   -- if nt = $unpacknumtype(zt)
-  -- if $ztbytes(zt, c)^n = $data(z, y).DATA[i : n * $storagesize(zt)/8]
+  -- if $ztbytes(zt, c)^n = $group_bytes_by(n, $data(z, y).DATA[i : n * $storagesize(zt)/8])
 
 
 rule Step_read/array.get-null:

--- a/spectec/spec/A-binary.watsup
+++ b/spectec/spec/A-binary.watsup
@@ -44,10 +44,6 @@ grammar Bf64 : f64 = | p:Bf(64) => p
 
 ;; Names
 
-def $concat_bytes(byte**) : byte*  hint(show $concat(%))
-def $concat_bytes(epsilon) = epsilon
-def $concat_bytes(b* b'**) = b* $concat_bytes(b'**)
-
 def $utf8(name) : byte*
 def $utf8(c) = b  -- if c < U+0080 /\ c = b
 def $utf8(c) = b_1 b_2  -- if U+0080 <= c < U+0800 /\ c = $(2^6*(b_1 - 0xC0) + (b_2 - 0x80))


### PR DESCRIPTION
This proposes a fix to the current reduction rule of `ARRAY.NEW_DATA`.

```
rule Step_read/array.new_data-alloc:
  z; (CONST I32 i) (CONST I32 n) (ARRAY.NEW_DATA x y)  ~>  (CONST nt c)^n (ARRAY.NEW_FIXED x n)
  -- Expand: $type(z, x) ~~ ARRAY (mut zt)
  -- if nt = $unpacknumtype(zt)
  -- if $ztbytes(zt, c)^n = $data(z, y).DATA[i : n * $storagesize(zt)/8]
```

There is a dimension mismatch in the last premise.

The lhs, `$ztbytes(zt, c)^n`, is a 2d-list of length `n`, with each element as a byte sequence of length `$storagesize(zt)/8`.
The rhs, `$data(z, y).DATA[i : n * $storagesize(zt)/8]` is a 1d-list of bytes with length `n * $storagesize(zt)/8`.

The elaboration pass somehow adds `[ ]` to `$data(z, y)` in effort to match the dimensions as follows.

```
-- if ($ztbytes(zt, c)^n{c} = [$data(z, y).DATA_datainst][i : ((n * $storagesize(zt)) / 8)])
```

Although both are now 2d-lists, it is incorrect since the rhs is a single-element 2d-list, while it should actually be a 2d-list of `n` elements.

So I propose adding a new helper function `$group_bytes_by(n, bytes*)` which groups a 1d-list of `bytes*` by `n`, producing a 2d-list.

Then the premise can be rewritten as,

```
  -- if $ztbytes(zt, c)^n = $group_bytes_by(n, $data(z, y).DATA[i : n * $storagesize(zt)/8])
```