### PR TITLE
Generalizing some vector operations

### DIFF
--- a/spectec/spec/wasm-2.0/1-syntax.watsup
+++ b/spectec/spec/wasm-2.0/1-syntax.watsup
@@ -210,6 +210,8 @@ syntax shiftopVIXX = | SHL | SHR sx
 syntax unopVFXX = | ABS | NEG | SQRT | CEIL | FLOOR | TRUNC | NEAREST
 syntax binopVFXX = | ADD | SUB | MUL | DIV | MIN | MAX | PMIN | PMAX
 
+syntax viunop = | unopVIXX | POPCNT
+syntax vibinop = | binopVIXX | minmaxopVIXX | satbinopVIXX | MUL | AVGR_U | Q15MULR_SAT_S
 
 syntax unop_vvectype = | _VV unopVVXX
 syntax binop_vvectype = | _VV binopVVXX
@@ -217,8 +219,8 @@ syntax ternop_vvectype = | _VV ternopVVXX
 syntax testop_vvectype = | _VV testopVVXX
 
 syntax shiftop_vectype = | _VI shiftopVIXX
-syntax unop_vectype = | _VI unopVIXX | _VF unopVFXX | POPCNT
-syntax binop_vectype = | _VI binopVIXX minmaxopVIXX satbinopVIXX | _VF binopVFXX | MUL | AVGR_U | Q15MULR_SAT_S
+syntax unop_vectype = | _VI viunop | _VF unopVFXX
+syntax binop_vectype = | _VI vibinop | _VF binopVFXX
 syntax testop_vectype = | _VI testopVIXX
 syntax relop_vectype = | _VI relopVIXX | _VF relopVFXX
 syntax cvtop_vectype = | EXTEND | TRUNC_SAT | CONVERT | DEMOTE | PROMOTE

--- a/spectec/spec/wasm-3.0/1-syntax.watsup
+++ b/spectec/spec/wasm-3.0/1-syntax.watsup
@@ -271,6 +271,8 @@ syntax shiftopVIXX = | SHL | SHR sx
 syntax unopVFXX = | ABS | NEG | SQRT | CEIL | FLOOR | TRUNC | NEAREST
 syntax binopVFXX = | ADD | SUB | MUL | DIV | MIN | MAX | PMIN | PMAX
 
+syntax viunop = | unopVIXX | POPCNT
+syntax vibinop = | binopVIXX | minmaxopVIXX | satbinopVIXX | MUL | AVGR_U | Q15MULR_SAT_S
 
 syntax unop_vvectype = | _VV unopVVXX
 syntax binop_vvectype = | _VV binopVVXX
@@ -278,8 +280,8 @@ syntax ternop_vvectype = | _VV ternopVVXX
 syntax testop_vvectype = | _VV testopVVXX
 
 syntax shiftop_vectype = | _VI shiftopVIXX
-syntax unop_vectype = | _VI unopVIXX | _VF unopVFXX | POPCNT
-syntax binop_vectype = | _VI binopVIXX minmaxopVIXX satbinopVIXX | _VF binopVFXX | MUL | AVGR_U | Q15MULR_SAT_S
+syntax unop_vectype = | _VI viunop | _VF unopVFXX
+syntax binop_vectype = | _VI vibinop | _VF binopVFXX
 syntax testop_vectype = | _VI testopVIXX
 syntax relop_vectype = | _VI relopVIXX | _VF relopVFXX
 syntax cvtop_vectype = | EXTEND | TRUNC_SAT | CONVERT | DEMOTE | PROMOTE

--- a/spectec/test-frontend/TEST.md
+++ b/spectec/test-frontend/TEST.md
@@ -815,50 +815,65 @@ syntax binopVFXX =
   | PMIN
   | PMAX
 
-;; 1-syntax.watsup:275.1-275.38
-syntax unop_vvectype =
-  | _VV(unopVVXX)
-
-;; 1-syntax.watsup:276.1-276.40
-syntax binop_vvectype =
-  | _VV(binopVVXX)
-
-;; 1-syntax.watsup:277.1-277.42
-syntax ternop_vvectype =
-  | _VV(ternopVVXX)
-
-;; 1-syntax.watsup:278.1-278.42
-syntax testop_vvectype =
-  | _VV(testopVVXX)
-
-;; 1-syntax.watsup:280.1-280.43
-syntax shiftop_vectype =
-  | _VI(shiftopVIXX)
-
-;; 1-syntax.watsup:281.1-281.61
-syntax unop_vectype =
-  | _VI(unopVIXX)
-  | _VF(unopVFXX)
+;; 1-syntax.watsup:274.1-274.36
+syntax viunop =
+  | ABS
+  | NEG
   | POPCNT
 
-;; 1-syntax.watsup:282.1-282.112
-syntax binop_vectype =
-  | _VI(binopVIXX, minmaxopVIXX, satbinopVIXX)
-  | _VF(binopVFXX)
+;; 1-syntax.watsup:275.1-275.90
+syntax vibinop =
+  | ADD
+  | SUB
+  | SWIZZLE
+  | MIN(sx)
+  | MAX(sx)
+  | ADD_SAT(sx)
+  | SUB_SAT(sx)
   | MUL
   | AVGR_U
   | Q15MULR_SAT_S
 
-;; 1-syntax.watsup:283.1-283.41
+;; 1-syntax.watsup:277.1-277.38
+syntax unop_vvectype =
+  | _VV(unopVVXX)
+
+;; 1-syntax.watsup:278.1-278.40
+syntax binop_vvectype =
+  | _VV(binopVVXX)
+
+;; 1-syntax.watsup:279.1-279.42
+syntax ternop_vvectype =
+  | _VV(ternopVVXX)
+
+;; 1-syntax.watsup:280.1-280.42
+syntax testop_vvectype =
+  | _VV(testopVVXX)
+
+;; 1-syntax.watsup:282.1-282.43
+syntax shiftop_vectype =
+  | _VI(shiftopVIXX)
+
+;; 1-syntax.watsup:283.1-283.50
+syntax unop_vectype =
+  | _VI(viunop)
+  | _VF(unopVFXX)
+
+;; 1-syntax.watsup:284.1-284.53
+syntax binop_vectype =
+  | _VI(vibinop)
+  | _VF(binopVFXX)
+
+;; 1-syntax.watsup:285.1-285.41
 syntax testop_vectype =
   | _VI(testopVIXX)
 
-;; 1-syntax.watsup:284.1-284.55
+;; 1-syntax.watsup:286.1-286.55
 syntax relop_vectype =
   | _VI(relopVIXX)
   | _VF(relopVFXX)
 
-;; 1-syntax.watsup:285.1-285.73
+;; 1-syntax.watsup:287.1-287.73
 syntax cvtop_vectype =
   | EXTEND
   | TRUNC_SAT
@@ -866,32 +881,32 @@ syntax cvtop_vectype =
   | DEMOTE
   | PROMOTE
 
-;; 1-syntax.watsup:303.1-303.68
+;; 1-syntax.watsup:305.1-305.68
 syntax memop = {ALIGN u32, OFFSET u32}
 
-;; 1-syntax.watsup:313.1-313.15
+;; 1-syntax.watsup:315.1-315.15
 syntax c = nat
 
-;; 1-syntax.watsup:314.1-314.23
+;; 1-syntax.watsup:316.1-316.23
 syntax c_numtype = nat
 
-;; 1-syntax.watsup:315.1-315.23
+;; 1-syntax.watsup:317.1-317.23
 syntax c_vectype = nat
 
-;; 1-syntax.watsup:318.1-320.17
+;; 1-syntax.watsup:320.1-322.17
 syntax blocktype =
   | _RESULT(valtype?)
   | _IDX(funcidx)
 
-;; 1-syntax.watsup:361.1-361.27
+;; 1-syntax.watsup:363.1-363.27
 syntax half =
   | LOW
   | HIGH
 
-;; 1-syntax.watsup:359.1-359.45
+;; 1-syntax.watsup:361.1-361.45
 syntax lanesize = nat
 
-;; 1-syntax.watsup:358.1-358.64
+;; 1-syntax.watsup:360.1-360.64
 syntax lanetype =
   | I8
   | I16
@@ -900,25 +915,25 @@ syntax lanetype =
   | F32
   | F64
 
-;; 1-syntax.watsup:360.1-360.54
+;; 1-syntax.watsup:362.1-362.54
 syntax shape = `%X%`(lanetype, lanesize)
 
-;; 1-syntax.watsup:450.1-450.29
+;; 1-syntax.watsup:452.1-452.29
 syntax packshape = `%X%`(nat, nat)
 
-;; 1-syntax.watsup:451.1-454.44
+;; 1-syntax.watsup:453.1-456.44
 syntax vloadop =
   | SHAPE(packshape, sx)
   | SPLAT(nat)
   | ZERO(nat)
 
-;; 1-syntax.watsup:362.1-362.20
+;; 1-syntax.watsup:364.1-364.20
 syntax zero = `ZERO%?`(()?)
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 rec {
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 syntax instr =
   | UNREACHABLE
   | NOP
@@ -1023,61 +1038,61 @@ syntax instr =
   | VSTORE_LANE(n, memidx, memop, laneidx)
 }
 
-;; 1-syntax.watsup:470.1-471.9
+;; 1-syntax.watsup:472.1-473.9
 syntax expr = instr*
 
-;; 1-syntax.watsup:483.1-483.61
+;; 1-syntax.watsup:485.1-485.61
 syntax elemmode =
   | ACTIVE(tableidx, expr)
   | PASSIVE
   | DECLARE
 
-;; 1-syntax.watsup:484.1-484.49
+;; 1-syntax.watsup:486.1-486.49
 syntax datamode =
   | ACTIVE(memidx, expr)
   | PASSIVE
 
-;; 1-syntax.watsup:486.1-487.15
+;; 1-syntax.watsup:488.1-489.15
 syntax type = TYPE(rectype)
 
-;; 1-syntax.watsup:488.1-489.16
+;; 1-syntax.watsup:490.1-491.16
 syntax local = LOCAL(valtype)
 
-;; 1-syntax.watsup:490.1-491.27
+;; 1-syntax.watsup:492.1-493.27
 syntax func = `FUNC%%*%`(typeidx, local*, expr)
 
-;; 1-syntax.watsup:492.1-493.25
+;; 1-syntax.watsup:494.1-495.25
 syntax global = GLOBAL(globaltype, expr)
 
-;; 1-syntax.watsup:494.1-495.23
+;; 1-syntax.watsup:496.1-497.23
 syntax table = TABLE(tabletype, expr)
 
-;; 1-syntax.watsup:496.1-497.17
+;; 1-syntax.watsup:498.1-499.17
 syntax mem = MEMORY(memtype)
 
-;; 1-syntax.watsup:498.1-499.30
+;; 1-syntax.watsup:500.1-501.30
 syntax elem = `ELEM%%*%`(reftype, expr*, elemmode)
 
-;; 1-syntax.watsup:500.1-501.22
+;; 1-syntax.watsup:502.1-503.22
 syntax data = `DATA%*%`(byte*, datamode)
 
-;; 1-syntax.watsup:502.1-503.16
+;; 1-syntax.watsup:504.1-505.16
 syntax start = START(funcidx)
 
-;; 1-syntax.watsup:505.1-506.66
+;; 1-syntax.watsup:507.1-508.66
 syntax externidx =
   | FUNC(funcidx)
   | GLOBAL(globalidx)
   | TABLE(tableidx)
   | MEM(memidx)
 
-;; 1-syntax.watsup:507.1-508.24
+;; 1-syntax.watsup:509.1-510.24
 syntax export = EXPORT(name, externidx)
 
-;; 1-syntax.watsup:509.1-510.30
+;; 1-syntax.watsup:511.1-512.30
 syntax import = IMPORT(name, name, externtype)
 
-;; 1-syntax.watsup:512.1-513.76
+;; 1-syntax.watsup:514.1-515.76
 syntax module = `MODULE%*%*%*%*%*%*%*%*%*%*`(type*, import*, func*, global*, table*, mem*, elem*, data*, start*, export*)
 
 ;; 2-syntax-aux.watsup:8.1-8.33

--- a/spectec/test-latex/TEST.md
+++ b/spectec/test-latex/TEST.md
@@ -451,20 +451,15 @@ $$
 & {\mathit{shiftopVIXX}} &::=& \mathsf{shl} ~|~ {\mathsf{shr\_}}{{\mathit{sx}}} \\
 & {\mathit{unopVFXX}} &::=& \mathsf{abs} ~|~ \mathsf{neg} ~|~ \mathsf{sqrt} ~|~ \mathsf{ceil} ~|~ \mathsf{floor} ~|~ \mathsf{trunc} ~|~ \mathsf{nearest} \\
 & {\mathit{binopVFXX}} &::=& \mathsf{add} ~|~ \mathsf{sub} ~|~ \mathsf{mul} ~|~ \mathsf{div} ~|~ \mathsf{min} ~|~ \mathsf{max} ~|~ \mathsf{pmin} ~|~ \mathsf{pmax} \\
-\end{array}
-$$
-
-\vspace{1ex}
-
-$$
-\begin{array}{@{}lrrl@{}l@{}}
+& {\mathit{viunop}} &::=& {\mathit{unopVIXX}} ~|~ \mathsf{popcnt} \\
+& {\mathit{vibinop}} &::=& {\mathit{binopVIXX}} ~|~ {\mathit{minmaxopVIXX}} ~|~ {\mathit{satbinopVIXX}} ~|~ \mathsf{mul} ~|~ \mathsf{avgr\_u} ~|~ \mathsf{q{\scriptstyle15}mulr\_sat\_s} \\
 & {\mathit{unop}}_{{\mathit{vvectype}}} &::=& {\mathit{unopVVXX}} \\
 & {\mathit{binop}}_{{\mathit{vvectype}}} &::=& {\mathit{binopVVXX}} \\
 & {\mathit{ternop}}_{{\mathit{vvectype}}} &::=& {\mathit{ternopVVXX}} \\
 & {\mathit{testop}}_{{\mathit{vvectype}}} &::=& {\mathit{testopVVXX}} \\
 & {\mathit{shiftop}}_{{\mathit{vectype}}} &::=& {\mathit{shiftopVIXX}} \\
-& {\mathit{unop}}_{{\mathit{vectype}}} &::=& {\mathit{unopVIXX}} ~|~ {\mathit{unopVFXX}} ~|~ \mathsf{popcnt} \\
-& {\mathit{binop}}_{{\mathit{vectype}}} &::=& {\mathit{binopVIXX}}~{\mathit{minmaxopVIXX}}~{\mathit{satbinopVIXX}} ~|~ {\mathit{binopVFXX}} ~|~ \mathsf{mul} ~|~ \mathsf{avgr\_u} ~|~ \mathsf{q{\scriptstyle15}mulr\_sat\_s} \\
+& {\mathit{unop}}_{{\mathit{vectype}}} &::=& {\mathit{viunop}} ~|~ {\mathit{unopVFXX}} \\
+& {\mathit{binop}}_{{\mathit{vectype}}} &::=& {\mathit{vibinop}} ~|~ {\mathit{binopVFXX}} \\
 & {\mathit{testop}}_{{\mathit{vectype}}} &::=& {\mathit{testopVIXX}} \\
 & {\mathit{relop}}_{{\mathit{vectype}}} &::=& {\mathit{relopVIXX}} ~|~ {\mathit{relopVFXX}} \\
 & {\mathit{cvtop}}_{{\mathit{vectype}}} &::=& \mathsf{extend} ~|~ \mathsf{trunc\_sat} ~|~ \mathsf{convert} ~|~ \mathsf{demote} ~|~ \mathsf{promote} \\

--- a/spectec/test-middlend/TEST.md
+++ b/spectec/test-middlend/TEST.md
@@ -665,50 +665,65 @@ syntax binopVFXX =
   | PMIN
   | PMAX
 
-;; 1-syntax.watsup:275.1-275.38
-syntax unop_vvectype =
-  | _VV(unopVVXX)
-
-;; 1-syntax.watsup:276.1-276.40
-syntax binop_vvectype =
-  | _VV(binopVVXX)
-
-;; 1-syntax.watsup:277.1-277.42
-syntax ternop_vvectype =
-  | _VV(ternopVVXX)
-
-;; 1-syntax.watsup:278.1-278.42
-syntax testop_vvectype =
-  | _VV(testopVVXX)
-
-;; 1-syntax.watsup:280.1-280.43
-syntax shiftop_vectype =
-  | _VI(shiftopVIXX)
-
-;; 1-syntax.watsup:281.1-281.61
-syntax unop_vectype =
-  | _VI(unopVIXX)
-  | _VF(unopVFXX)
+;; 1-syntax.watsup:274.1-274.36
+syntax viunop =
+  | ABS
+  | NEG
   | POPCNT
 
-;; 1-syntax.watsup:282.1-282.112
-syntax binop_vectype =
-  | _VI(binopVIXX, minmaxopVIXX, satbinopVIXX)
-  | _VF(binopVFXX)
+;; 1-syntax.watsup:275.1-275.90
+syntax vibinop =
+  | ADD
+  | SUB
+  | SWIZZLE
+  | MIN(sx)
+  | MAX(sx)
+  | ADD_SAT(sx)
+  | SUB_SAT(sx)
   | MUL
   | AVGR_U
   | Q15MULR_SAT_S
 
-;; 1-syntax.watsup:283.1-283.41
+;; 1-syntax.watsup:277.1-277.38
+syntax unop_vvectype =
+  | _VV(unopVVXX)
+
+;; 1-syntax.watsup:278.1-278.40
+syntax binop_vvectype =
+  | _VV(binopVVXX)
+
+;; 1-syntax.watsup:279.1-279.42
+syntax ternop_vvectype =
+  | _VV(ternopVVXX)
+
+;; 1-syntax.watsup:280.1-280.42
+syntax testop_vvectype =
+  | _VV(testopVVXX)
+
+;; 1-syntax.watsup:282.1-282.43
+syntax shiftop_vectype =
+  | _VI(shiftopVIXX)
+
+;; 1-syntax.watsup:283.1-283.50
+syntax unop_vectype =
+  | _VI(viunop)
+  | _VF(unopVFXX)
+
+;; 1-syntax.watsup:284.1-284.53
+syntax binop_vectype =
+  | _VI(vibinop)
+  | _VF(binopVFXX)
+
+;; 1-syntax.watsup:285.1-285.41
 syntax testop_vectype =
   | _VI(testopVIXX)
 
-;; 1-syntax.watsup:284.1-284.55
+;; 1-syntax.watsup:286.1-286.55
 syntax relop_vectype =
   | _VI(relopVIXX)
   | _VF(relopVFXX)
 
-;; 1-syntax.watsup:285.1-285.73
+;; 1-syntax.watsup:287.1-287.73
 syntax cvtop_vectype =
   | EXTEND
   | TRUNC_SAT
@@ -716,32 +731,32 @@ syntax cvtop_vectype =
   | DEMOTE
   | PROMOTE
 
-;; 1-syntax.watsup:303.1-303.68
+;; 1-syntax.watsup:305.1-305.68
 syntax memop = {ALIGN u32, OFFSET u32}
 
-;; 1-syntax.watsup:313.1-313.15
+;; 1-syntax.watsup:315.1-315.15
 syntax c = nat
 
-;; 1-syntax.watsup:314.1-314.23
+;; 1-syntax.watsup:316.1-316.23
 syntax c_numtype = nat
 
-;; 1-syntax.watsup:315.1-315.23
+;; 1-syntax.watsup:317.1-317.23
 syntax c_vectype = nat
 
-;; 1-syntax.watsup:318.1-320.17
+;; 1-syntax.watsup:320.1-322.17
 syntax blocktype =
   | _RESULT(valtype?)
   | _IDX(funcidx)
 
-;; 1-syntax.watsup:361.1-361.27
+;; 1-syntax.watsup:363.1-363.27
 syntax half =
   | LOW
   | HIGH
 
-;; 1-syntax.watsup:359.1-359.45
+;; 1-syntax.watsup:361.1-361.45
 syntax lanesize = nat
 
-;; 1-syntax.watsup:358.1-358.64
+;; 1-syntax.watsup:360.1-360.64
 syntax lanetype =
   | I8
   | I16
@@ -750,25 +765,25 @@ syntax lanetype =
   | F32
   | F64
 
-;; 1-syntax.watsup:360.1-360.54
+;; 1-syntax.watsup:362.1-362.54
 syntax shape = `%X%`(lanetype, lanesize)
 
-;; 1-syntax.watsup:450.1-450.29
+;; 1-syntax.watsup:452.1-452.29
 syntax packshape = `%X%`(nat, nat)
 
-;; 1-syntax.watsup:451.1-454.44
+;; 1-syntax.watsup:453.1-456.44
 syntax vloadop =
   | SHAPE(packshape, sx)
   | SPLAT(nat)
   | ZERO(nat)
 
-;; 1-syntax.watsup:362.1-362.20
+;; 1-syntax.watsup:364.1-364.20
 syntax zero = `ZERO%?`(()?)
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 rec {
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 syntax instr =
   | UNREACHABLE
   | NOP
@@ -873,61 +888,61 @@ syntax instr =
   | VSTORE_LANE(n, memidx, memop, laneidx)
 }
 
-;; 1-syntax.watsup:470.1-471.9
+;; 1-syntax.watsup:472.1-473.9
 syntax expr = instr*
 
-;; 1-syntax.watsup:483.1-483.61
+;; 1-syntax.watsup:485.1-485.61
 syntax elemmode =
   | ACTIVE(tableidx, expr)
   | PASSIVE
   | DECLARE
 
-;; 1-syntax.watsup:484.1-484.49
+;; 1-syntax.watsup:486.1-486.49
 syntax datamode =
   | ACTIVE(memidx, expr)
   | PASSIVE
 
-;; 1-syntax.watsup:486.1-487.15
+;; 1-syntax.watsup:488.1-489.15
 syntax type = TYPE(rectype)
 
-;; 1-syntax.watsup:488.1-489.16
+;; 1-syntax.watsup:490.1-491.16
 syntax local = LOCAL(valtype)
 
-;; 1-syntax.watsup:490.1-491.27
+;; 1-syntax.watsup:492.1-493.27
 syntax func = `FUNC%%*%`(typeidx, local*, expr)
 
-;; 1-syntax.watsup:492.1-493.25
+;; 1-syntax.watsup:494.1-495.25
 syntax global = GLOBAL(globaltype, expr)
 
-;; 1-syntax.watsup:494.1-495.23
+;; 1-syntax.watsup:496.1-497.23
 syntax table = TABLE(tabletype, expr)
 
-;; 1-syntax.watsup:496.1-497.17
+;; 1-syntax.watsup:498.1-499.17
 syntax mem = MEMORY(memtype)
 
-;; 1-syntax.watsup:498.1-499.30
+;; 1-syntax.watsup:500.1-501.30
 syntax elem = `ELEM%%*%`(reftype, expr*, elemmode)
 
-;; 1-syntax.watsup:500.1-501.22
+;; 1-syntax.watsup:502.1-503.22
 syntax data = `DATA%*%`(byte*, datamode)
 
-;; 1-syntax.watsup:502.1-503.16
+;; 1-syntax.watsup:504.1-505.16
 syntax start = START(funcidx)
 
-;; 1-syntax.watsup:505.1-506.66
+;; 1-syntax.watsup:507.1-508.66
 syntax externidx =
   | FUNC(funcidx)
   | GLOBAL(globalidx)
   | TABLE(tableidx)
   | MEM(memidx)
 
-;; 1-syntax.watsup:507.1-508.24
+;; 1-syntax.watsup:509.1-510.24
 syntax export = EXPORT(name, externidx)
 
-;; 1-syntax.watsup:509.1-510.30
+;; 1-syntax.watsup:511.1-512.30
 syntax import = IMPORT(name, name, externtype)
 
-;; 1-syntax.watsup:512.1-513.76
+;; 1-syntax.watsup:514.1-515.76
 syntax module = `MODULE%*%*%*%*%*%*%*%*%*%*`(type*, import*, func*, global*, table*, mem*, elem*, data*, start*, export*)
 
 ;; 2-syntax-aux.watsup:8.1-8.33
@@ -5399,50 +5414,65 @@ syntax binopVFXX =
   | PMIN
   | PMAX
 
-;; 1-syntax.watsup:275.1-275.38
-syntax unop_vvectype =
-  | _VV(unopVVXX)
-
-;; 1-syntax.watsup:276.1-276.40
-syntax binop_vvectype =
-  | _VV(binopVVXX)
-
-;; 1-syntax.watsup:277.1-277.42
-syntax ternop_vvectype =
-  | _VV(ternopVVXX)
-
-;; 1-syntax.watsup:278.1-278.42
-syntax testop_vvectype =
-  | _VV(testopVVXX)
-
-;; 1-syntax.watsup:280.1-280.43
-syntax shiftop_vectype =
-  | _VI(shiftopVIXX)
-
-;; 1-syntax.watsup:281.1-281.61
-syntax unop_vectype =
-  | _VI(unopVIXX)
-  | _VF(unopVFXX)
+;; 1-syntax.watsup:274.1-274.36
+syntax viunop =
+  | ABS
+  | NEG
   | POPCNT
 
-;; 1-syntax.watsup:282.1-282.112
-syntax binop_vectype =
-  | _VI(binopVIXX, minmaxopVIXX, satbinopVIXX)
-  | _VF(binopVFXX)
+;; 1-syntax.watsup:275.1-275.90
+syntax vibinop =
+  | ADD
+  | SUB
+  | SWIZZLE
+  | MIN(sx)
+  | MAX(sx)
+  | ADD_SAT(sx)
+  | SUB_SAT(sx)
   | MUL
   | AVGR_U
   | Q15MULR_SAT_S
 
-;; 1-syntax.watsup:283.1-283.41
+;; 1-syntax.watsup:277.1-277.38
+syntax unop_vvectype =
+  | _VV(unopVVXX)
+
+;; 1-syntax.watsup:278.1-278.40
+syntax binop_vvectype =
+  | _VV(binopVVXX)
+
+;; 1-syntax.watsup:279.1-279.42
+syntax ternop_vvectype =
+  | _VV(ternopVVXX)
+
+;; 1-syntax.watsup:280.1-280.42
+syntax testop_vvectype =
+  | _VV(testopVVXX)
+
+;; 1-syntax.watsup:282.1-282.43
+syntax shiftop_vectype =
+  | _VI(shiftopVIXX)
+
+;; 1-syntax.watsup:283.1-283.50
+syntax unop_vectype =
+  | _VI(viunop)
+  | _VF(unopVFXX)
+
+;; 1-syntax.watsup:284.1-284.53
+syntax binop_vectype =
+  | _VI(vibinop)
+  | _VF(binopVFXX)
+
+;; 1-syntax.watsup:285.1-285.41
 syntax testop_vectype =
   | _VI(testopVIXX)
 
-;; 1-syntax.watsup:284.1-284.55
+;; 1-syntax.watsup:286.1-286.55
 syntax relop_vectype =
   | _VI(relopVIXX)
   | _VF(relopVFXX)
 
-;; 1-syntax.watsup:285.1-285.73
+;; 1-syntax.watsup:287.1-287.73
 syntax cvtop_vectype =
   | EXTEND
   | TRUNC_SAT
@@ -5450,32 +5480,32 @@ syntax cvtop_vectype =
   | DEMOTE
   | PROMOTE
 
-;; 1-syntax.watsup:303.1-303.68
+;; 1-syntax.watsup:305.1-305.68
 syntax memop = {ALIGN u32, OFFSET u32}
 
-;; 1-syntax.watsup:313.1-313.15
+;; 1-syntax.watsup:315.1-315.15
 syntax c = nat
 
-;; 1-syntax.watsup:314.1-314.23
+;; 1-syntax.watsup:316.1-316.23
 syntax c_numtype = nat
 
-;; 1-syntax.watsup:315.1-315.23
+;; 1-syntax.watsup:317.1-317.23
 syntax c_vectype = nat
 
-;; 1-syntax.watsup:318.1-320.17
+;; 1-syntax.watsup:320.1-322.17
 syntax blocktype =
   | _RESULT(valtype?)
   | _IDX(funcidx)
 
-;; 1-syntax.watsup:361.1-361.27
+;; 1-syntax.watsup:363.1-363.27
 syntax half =
   | LOW
   | HIGH
 
-;; 1-syntax.watsup:359.1-359.45
+;; 1-syntax.watsup:361.1-361.45
 syntax lanesize = nat
 
-;; 1-syntax.watsup:358.1-358.64
+;; 1-syntax.watsup:360.1-360.64
 syntax lanetype =
   | I8
   | I16
@@ -5494,25 +5524,25 @@ def lanetype_packedtype : packedtype -> lanetype
   def lanetype_packedtype(I8_packedtype) = I8_lanetype
   def lanetype_packedtype(I16_packedtype) = I16_lanetype
 
-;; 1-syntax.watsup:360.1-360.54
+;; 1-syntax.watsup:362.1-362.54
 syntax shape = `%X%`(lanetype, lanesize)
 
-;; 1-syntax.watsup:450.1-450.29
+;; 1-syntax.watsup:452.1-452.29
 syntax packshape = `%X%`(nat, nat)
 
-;; 1-syntax.watsup:451.1-454.44
+;; 1-syntax.watsup:453.1-456.44
 syntax vloadop =
   | SHAPE(packshape, sx)
   | SPLAT(nat)
   | ZERO(nat)
 
-;; 1-syntax.watsup:362.1-362.20
+;; 1-syntax.watsup:364.1-364.20
 syntax zero = `ZERO%?`(()?)
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 rec {
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 syntax instr =
   | UNREACHABLE
   | NOP
@@ -5617,61 +5647,61 @@ syntax instr =
   | VSTORE_LANE(n, memidx, memop, laneidx)
 }
 
-;; 1-syntax.watsup:470.1-471.9
+;; 1-syntax.watsup:472.1-473.9
 syntax expr = instr*
 
-;; 1-syntax.watsup:483.1-483.61
+;; 1-syntax.watsup:485.1-485.61
 syntax elemmode =
   | ACTIVE(tableidx, expr)
   | PASSIVE
   | DECLARE
 
-;; 1-syntax.watsup:484.1-484.49
+;; 1-syntax.watsup:486.1-486.49
 syntax datamode =
   | ACTIVE(memidx, expr)
   | PASSIVE
 
-;; 1-syntax.watsup:486.1-487.15
+;; 1-syntax.watsup:488.1-489.15
 syntax type = TYPE(rectype)
 
-;; 1-syntax.watsup:488.1-489.16
+;; 1-syntax.watsup:490.1-491.16
 syntax local = LOCAL(valtype)
 
-;; 1-syntax.watsup:490.1-491.27
+;; 1-syntax.watsup:492.1-493.27
 syntax func = `FUNC%%*%`(typeidx, local*, expr)
 
-;; 1-syntax.watsup:492.1-493.25
+;; 1-syntax.watsup:494.1-495.25
 syntax global = GLOBAL(globaltype, expr)
 
-;; 1-syntax.watsup:494.1-495.23
+;; 1-syntax.watsup:496.1-497.23
 syntax table = TABLE(tabletype, expr)
 
-;; 1-syntax.watsup:496.1-497.17
+;; 1-syntax.watsup:498.1-499.17
 syntax mem = MEMORY(memtype)
 
-;; 1-syntax.watsup:498.1-499.30
+;; 1-syntax.watsup:500.1-501.30
 syntax elem = `ELEM%%*%`(reftype, expr*, elemmode)
 
-;; 1-syntax.watsup:500.1-501.22
+;; 1-syntax.watsup:502.1-503.22
 syntax data = `DATA%*%`(byte*, datamode)
 
-;; 1-syntax.watsup:502.1-503.16
+;; 1-syntax.watsup:504.1-505.16
 syntax start = START(funcidx)
 
-;; 1-syntax.watsup:505.1-506.66
+;; 1-syntax.watsup:507.1-508.66
 syntax externidx =
   | FUNC(funcidx)
   | GLOBAL(globalidx)
   | TABLE(tableidx)
   | MEM(memidx)
 
-;; 1-syntax.watsup:507.1-508.24
+;; 1-syntax.watsup:509.1-510.24
 syntax export = EXPORT(name, externidx)
 
-;; 1-syntax.watsup:509.1-510.30
+;; 1-syntax.watsup:511.1-512.30
 syntax import = IMPORT(name, name, externtype)
 
-;; 1-syntax.watsup:512.1-513.76
+;; 1-syntax.watsup:514.1-515.76
 syntax module = `MODULE%*%*%*%*%*%*%*%*%*%*`(type*, import*, func*, global*, table*, mem*, elem*, data*, start*, export*)
 
 ;; 2-syntax-aux.watsup:8.1-8.33
@@ -10298,50 +10328,65 @@ syntax binopVFXX =
   | PMIN
   | PMAX
 
-;; 1-syntax.watsup:275.1-275.38
-syntax unop_vvectype =
-  | _VV(unopVVXX)
-
-;; 1-syntax.watsup:276.1-276.40
-syntax binop_vvectype =
-  | _VV(binopVVXX)
-
-;; 1-syntax.watsup:277.1-277.42
-syntax ternop_vvectype =
-  | _VV(ternopVVXX)
-
-;; 1-syntax.watsup:278.1-278.42
-syntax testop_vvectype =
-  | _VV(testopVVXX)
-
-;; 1-syntax.watsup:280.1-280.43
-syntax shiftop_vectype =
-  | _VI(shiftopVIXX)
-
-;; 1-syntax.watsup:281.1-281.61
-syntax unop_vectype =
-  | _VI(unopVIXX)
-  | _VF(unopVFXX)
+;; 1-syntax.watsup:274.1-274.36
+syntax viunop =
+  | ABS
+  | NEG
   | POPCNT
 
-;; 1-syntax.watsup:282.1-282.112
-syntax binop_vectype =
-  | _VI(binopVIXX, minmaxopVIXX, satbinopVIXX)
-  | _VF(binopVFXX)
+;; 1-syntax.watsup:275.1-275.90
+syntax vibinop =
+  | ADD
+  | SUB
+  | SWIZZLE
+  | MIN(sx)
+  | MAX(sx)
+  | ADD_SAT(sx)
+  | SUB_SAT(sx)
   | MUL
   | AVGR_U
   | Q15MULR_SAT_S
 
-;; 1-syntax.watsup:283.1-283.41
+;; 1-syntax.watsup:277.1-277.38
+syntax unop_vvectype =
+  | _VV(unopVVXX)
+
+;; 1-syntax.watsup:278.1-278.40
+syntax binop_vvectype =
+  | _VV(binopVVXX)
+
+;; 1-syntax.watsup:279.1-279.42
+syntax ternop_vvectype =
+  | _VV(ternopVVXX)
+
+;; 1-syntax.watsup:280.1-280.42
+syntax testop_vvectype =
+  | _VV(testopVVXX)
+
+;; 1-syntax.watsup:282.1-282.43
+syntax shiftop_vectype =
+  | _VI(shiftopVIXX)
+
+;; 1-syntax.watsup:283.1-283.50
+syntax unop_vectype =
+  | _VI(viunop)
+  | _VF(unopVFXX)
+
+;; 1-syntax.watsup:284.1-284.53
+syntax binop_vectype =
+  | _VI(vibinop)
+  | _VF(binopVFXX)
+
+;; 1-syntax.watsup:285.1-285.41
 syntax testop_vectype =
   | _VI(testopVIXX)
 
-;; 1-syntax.watsup:284.1-284.55
+;; 1-syntax.watsup:286.1-286.55
 syntax relop_vectype =
   | _VI(relopVIXX)
   | _VF(relopVFXX)
 
-;; 1-syntax.watsup:285.1-285.73
+;; 1-syntax.watsup:287.1-287.73
 syntax cvtop_vectype =
   | EXTEND
   | TRUNC_SAT
@@ -10349,32 +10394,32 @@ syntax cvtop_vectype =
   | DEMOTE
   | PROMOTE
 
-;; 1-syntax.watsup:303.1-303.68
+;; 1-syntax.watsup:305.1-305.68
 syntax memop = {ALIGN u32, OFFSET u32}
 
-;; 1-syntax.watsup:313.1-313.15
+;; 1-syntax.watsup:315.1-315.15
 syntax c = nat
 
-;; 1-syntax.watsup:314.1-314.23
+;; 1-syntax.watsup:316.1-316.23
 syntax c_numtype = nat
 
-;; 1-syntax.watsup:315.1-315.23
+;; 1-syntax.watsup:317.1-317.23
 syntax c_vectype = nat
 
-;; 1-syntax.watsup:318.1-320.17
+;; 1-syntax.watsup:320.1-322.17
 syntax blocktype =
   | _RESULT(valtype?)
   | _IDX(funcidx)
 
-;; 1-syntax.watsup:361.1-361.27
+;; 1-syntax.watsup:363.1-363.27
 syntax half =
   | LOW
   | HIGH
 
-;; 1-syntax.watsup:359.1-359.45
+;; 1-syntax.watsup:361.1-361.45
 syntax lanesize = nat
 
-;; 1-syntax.watsup:358.1-358.64
+;; 1-syntax.watsup:360.1-360.64
 syntax lanetype =
   | I8
   | I16
@@ -10393,25 +10438,25 @@ def lanetype_packedtype : packedtype -> lanetype
   def lanetype_packedtype(I8_packedtype) = I8_lanetype
   def lanetype_packedtype(I16_packedtype) = I16_lanetype
 
-;; 1-syntax.watsup:360.1-360.54
+;; 1-syntax.watsup:362.1-362.54
 syntax shape = `%X%`(lanetype, lanesize)
 
-;; 1-syntax.watsup:450.1-450.29
+;; 1-syntax.watsup:452.1-452.29
 syntax packshape = `%X%`(nat, nat)
 
-;; 1-syntax.watsup:451.1-454.44
+;; 1-syntax.watsup:453.1-456.44
 syntax vloadop =
   | SHAPE(packshape, sx)
   | SPLAT(nat)
   | ZERO(nat)
 
-;; 1-syntax.watsup:362.1-362.20
+;; 1-syntax.watsup:364.1-364.20
 syntax zero = `ZERO%?`(()?)
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 rec {
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 syntax instr =
   | UNREACHABLE
   | NOP
@@ -10516,61 +10561,61 @@ syntax instr =
   | VSTORE_LANE(n, memidx, memop, laneidx)
 }
 
-;; 1-syntax.watsup:470.1-471.9
+;; 1-syntax.watsup:472.1-473.9
 syntax expr = instr*
 
-;; 1-syntax.watsup:483.1-483.61
+;; 1-syntax.watsup:485.1-485.61
 syntax elemmode =
   | ACTIVE(tableidx, expr)
   | PASSIVE
   | DECLARE
 
-;; 1-syntax.watsup:484.1-484.49
+;; 1-syntax.watsup:486.1-486.49
 syntax datamode =
   | ACTIVE(memidx, expr)
   | PASSIVE
 
-;; 1-syntax.watsup:486.1-487.15
+;; 1-syntax.watsup:488.1-489.15
 syntax type = TYPE(rectype)
 
-;; 1-syntax.watsup:488.1-489.16
+;; 1-syntax.watsup:490.1-491.16
 syntax local = LOCAL(valtype)
 
-;; 1-syntax.watsup:490.1-491.27
+;; 1-syntax.watsup:492.1-493.27
 syntax func = `FUNC%%*%`(typeidx, local*, expr)
 
-;; 1-syntax.watsup:492.1-493.25
+;; 1-syntax.watsup:494.1-495.25
 syntax global = GLOBAL(globaltype, expr)
 
-;; 1-syntax.watsup:494.1-495.23
+;; 1-syntax.watsup:496.1-497.23
 syntax table = TABLE(tabletype, expr)
 
-;; 1-syntax.watsup:496.1-497.17
+;; 1-syntax.watsup:498.1-499.17
 syntax mem = MEMORY(memtype)
 
-;; 1-syntax.watsup:498.1-499.30
+;; 1-syntax.watsup:500.1-501.30
 syntax elem = `ELEM%%*%`(reftype, expr*, elemmode)
 
-;; 1-syntax.watsup:500.1-501.22
+;; 1-syntax.watsup:502.1-503.22
 syntax data = `DATA%*%`(byte*, datamode)
 
-;; 1-syntax.watsup:502.1-503.16
+;; 1-syntax.watsup:504.1-505.16
 syntax start = START(funcidx)
 
-;; 1-syntax.watsup:505.1-506.66
+;; 1-syntax.watsup:507.1-508.66
 syntax externidx =
   | FUNC(funcidx)
   | GLOBAL(globalidx)
   | TABLE(tableidx)
   | MEM(memidx)
 
-;; 1-syntax.watsup:507.1-508.24
+;; 1-syntax.watsup:509.1-510.24
 syntax export = EXPORT(name, externidx)
 
-;; 1-syntax.watsup:509.1-510.30
+;; 1-syntax.watsup:511.1-512.30
 syntax import = IMPORT(name, name, externtype)
 
-;; 1-syntax.watsup:512.1-513.76
+;; 1-syntax.watsup:514.1-515.76
 syntax module = `MODULE%*%*%*%*%*%*%*%*%*%*`(type*, import*, func*, global*, table*, mem*, elem*, data*, start*, export*)
 
 ;; 2-syntax-aux.watsup:8.1-8.33
@@ -15200,50 +15245,65 @@ syntax binopVFXX =
   | PMIN
   | PMAX
 
-;; 1-syntax.watsup:275.1-275.38
-syntax unop_vvectype =
-  | _VV(unopVVXX)
-
-;; 1-syntax.watsup:276.1-276.40
-syntax binop_vvectype =
-  | _VV(binopVVXX)
-
-;; 1-syntax.watsup:277.1-277.42
-syntax ternop_vvectype =
-  | _VV(ternopVVXX)
-
-;; 1-syntax.watsup:278.1-278.42
-syntax testop_vvectype =
-  | _VV(testopVVXX)
-
-;; 1-syntax.watsup:280.1-280.43
-syntax shiftop_vectype =
-  | _VI(shiftopVIXX)
-
-;; 1-syntax.watsup:281.1-281.61
-syntax unop_vectype =
-  | _VI(unopVIXX)
-  | _VF(unopVFXX)
+;; 1-syntax.watsup:274.1-274.36
+syntax viunop =
+  | ABS
+  | NEG
   | POPCNT
 
-;; 1-syntax.watsup:282.1-282.112
-syntax binop_vectype =
-  | _VI(binopVIXX, minmaxopVIXX, satbinopVIXX)
-  | _VF(binopVFXX)
+;; 1-syntax.watsup:275.1-275.90
+syntax vibinop =
+  | ADD
+  | SUB
+  | SWIZZLE
+  | MIN(sx)
+  | MAX(sx)
+  | ADD_SAT(sx)
+  | SUB_SAT(sx)
   | MUL
   | AVGR_U
   | Q15MULR_SAT_S
 
-;; 1-syntax.watsup:283.1-283.41
+;; 1-syntax.watsup:277.1-277.38
+syntax unop_vvectype =
+  | _VV(unopVVXX)
+
+;; 1-syntax.watsup:278.1-278.40
+syntax binop_vvectype =
+  | _VV(binopVVXX)
+
+;; 1-syntax.watsup:279.1-279.42
+syntax ternop_vvectype =
+  | _VV(ternopVVXX)
+
+;; 1-syntax.watsup:280.1-280.42
+syntax testop_vvectype =
+  | _VV(testopVVXX)
+
+;; 1-syntax.watsup:282.1-282.43
+syntax shiftop_vectype =
+  | _VI(shiftopVIXX)
+
+;; 1-syntax.watsup:283.1-283.50
+syntax unop_vectype =
+  | _VI(viunop)
+  | _VF(unopVFXX)
+
+;; 1-syntax.watsup:284.1-284.53
+syntax binop_vectype =
+  | _VI(vibinop)
+  | _VF(binopVFXX)
+
+;; 1-syntax.watsup:285.1-285.41
 syntax testop_vectype =
   | _VI(testopVIXX)
 
-;; 1-syntax.watsup:284.1-284.55
+;; 1-syntax.watsup:286.1-286.55
 syntax relop_vectype =
   | _VI(relopVIXX)
   | _VF(relopVFXX)
 
-;; 1-syntax.watsup:285.1-285.73
+;; 1-syntax.watsup:287.1-287.73
 syntax cvtop_vectype =
   | EXTEND
   | TRUNC_SAT
@@ -15251,32 +15311,32 @@ syntax cvtop_vectype =
   | DEMOTE
   | PROMOTE
 
-;; 1-syntax.watsup:303.1-303.68
+;; 1-syntax.watsup:305.1-305.68
 syntax memop = {ALIGN u32, OFFSET u32}
 
-;; 1-syntax.watsup:313.1-313.15
+;; 1-syntax.watsup:315.1-315.15
 syntax c = nat
 
-;; 1-syntax.watsup:314.1-314.23
+;; 1-syntax.watsup:316.1-316.23
 syntax c_numtype = nat
 
-;; 1-syntax.watsup:315.1-315.23
+;; 1-syntax.watsup:317.1-317.23
 syntax c_vectype = nat
 
-;; 1-syntax.watsup:318.1-320.17
+;; 1-syntax.watsup:320.1-322.17
 syntax blocktype =
   | _RESULT(valtype?)
   | _IDX(funcidx)
 
-;; 1-syntax.watsup:361.1-361.27
+;; 1-syntax.watsup:363.1-363.27
 syntax half =
   | LOW
   | HIGH
 
-;; 1-syntax.watsup:359.1-359.45
+;; 1-syntax.watsup:361.1-361.45
 syntax lanesize = nat
 
-;; 1-syntax.watsup:358.1-358.64
+;; 1-syntax.watsup:360.1-360.64
 syntax lanetype =
   | I8
   | I16
@@ -15295,25 +15355,25 @@ def lanetype_packedtype : packedtype -> lanetype
   def lanetype_packedtype(I8_packedtype) = I8_lanetype
   def lanetype_packedtype(I16_packedtype) = I16_lanetype
 
-;; 1-syntax.watsup:360.1-360.54
+;; 1-syntax.watsup:362.1-362.54
 syntax shape = `%X%`(lanetype, lanesize)
 
-;; 1-syntax.watsup:450.1-450.29
+;; 1-syntax.watsup:452.1-452.29
 syntax packshape = `%X%`(nat, nat)
 
-;; 1-syntax.watsup:451.1-454.44
+;; 1-syntax.watsup:453.1-456.44
 syntax vloadop =
   | SHAPE(packshape, sx)
   | SPLAT(nat)
   | ZERO(nat)
 
-;; 1-syntax.watsup:362.1-362.20
+;; 1-syntax.watsup:364.1-364.20
 syntax zero = `ZERO%?`(()?)
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 rec {
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 syntax instr =
   | UNREACHABLE
   | NOP
@@ -15418,61 +15478,61 @@ syntax instr =
   | VSTORE_LANE(n, memidx, memop, laneidx)
 }
 
-;; 1-syntax.watsup:470.1-471.9
+;; 1-syntax.watsup:472.1-473.9
 syntax expr = instr*
 
-;; 1-syntax.watsup:483.1-483.61
+;; 1-syntax.watsup:485.1-485.61
 syntax elemmode =
   | ACTIVE(tableidx, expr)
   | PASSIVE
   | DECLARE
 
-;; 1-syntax.watsup:484.1-484.49
+;; 1-syntax.watsup:486.1-486.49
 syntax datamode =
   | ACTIVE(memidx, expr)
   | PASSIVE
 
-;; 1-syntax.watsup:486.1-487.15
+;; 1-syntax.watsup:488.1-489.15
 syntax type = TYPE(rectype)
 
-;; 1-syntax.watsup:488.1-489.16
+;; 1-syntax.watsup:490.1-491.16
 syntax local = LOCAL(valtype)
 
-;; 1-syntax.watsup:490.1-491.27
+;; 1-syntax.watsup:492.1-493.27
 syntax func = `FUNC%%*%`(typeidx, local*, expr)
 
-;; 1-syntax.watsup:492.1-493.25
+;; 1-syntax.watsup:494.1-495.25
 syntax global = GLOBAL(globaltype, expr)
 
-;; 1-syntax.watsup:494.1-495.23
+;; 1-syntax.watsup:496.1-497.23
 syntax table = TABLE(tabletype, expr)
 
-;; 1-syntax.watsup:496.1-497.17
+;; 1-syntax.watsup:498.1-499.17
 syntax mem = MEMORY(memtype)
 
-;; 1-syntax.watsup:498.1-499.30
+;; 1-syntax.watsup:500.1-501.30
 syntax elem = `ELEM%%*%`(reftype, expr*, elemmode)
 
-;; 1-syntax.watsup:500.1-501.22
+;; 1-syntax.watsup:502.1-503.22
 syntax data = `DATA%*%`(byte*, datamode)
 
-;; 1-syntax.watsup:502.1-503.16
+;; 1-syntax.watsup:504.1-505.16
 syntax start = START(funcidx)
 
-;; 1-syntax.watsup:505.1-506.66
+;; 1-syntax.watsup:507.1-508.66
 syntax externidx =
   | FUNC(funcidx)
   | GLOBAL(globalidx)
   | TABLE(tableidx)
   | MEM(memidx)
 
-;; 1-syntax.watsup:507.1-508.24
+;; 1-syntax.watsup:509.1-510.24
 syntax export = EXPORT(name, externidx)
 
-;; 1-syntax.watsup:509.1-510.30
+;; 1-syntax.watsup:511.1-512.30
 syntax import = IMPORT(name, name, externtype)
 
-;; 1-syntax.watsup:512.1-513.76
+;; 1-syntax.watsup:514.1-515.76
 syntax module = `MODULE%*%*%*%*%*%*%*%*%*%*`(type*, import*, func*, global*, table*, mem*, elem*, data*, start*, export*)
 
 ;; 2-syntax-aux.watsup:8.1-8.33
@@ -20127,50 +20187,65 @@ syntax binopVFXX =
   | PMIN
   | PMAX
 
-;; 1-syntax.watsup:275.1-275.38
-syntax unop_vvectype =
-  | _VV(unopVVXX)
-
-;; 1-syntax.watsup:276.1-276.40
-syntax binop_vvectype =
-  | _VV(binopVVXX)
-
-;; 1-syntax.watsup:277.1-277.42
-syntax ternop_vvectype =
-  | _VV(ternopVVXX)
-
-;; 1-syntax.watsup:278.1-278.42
-syntax testop_vvectype =
-  | _VV(testopVVXX)
-
-;; 1-syntax.watsup:280.1-280.43
-syntax shiftop_vectype =
-  | _VI(shiftopVIXX)
-
-;; 1-syntax.watsup:281.1-281.61
-syntax unop_vectype =
-  | _VI(unopVIXX)
-  | _VF(unopVFXX)
+;; 1-syntax.watsup:274.1-274.36
+syntax viunop =
+  | ABS
+  | NEG
   | POPCNT
 
-;; 1-syntax.watsup:282.1-282.112
-syntax binop_vectype =
-  | _VI(binopVIXX, minmaxopVIXX, satbinopVIXX)
-  | _VF(binopVFXX)
+;; 1-syntax.watsup:275.1-275.90
+syntax vibinop =
+  | ADD
+  | SUB
+  | SWIZZLE
+  | MIN(sx)
+  | MAX(sx)
+  | ADD_SAT(sx)
+  | SUB_SAT(sx)
   | MUL
   | AVGR_U
   | Q15MULR_SAT_S
 
-;; 1-syntax.watsup:283.1-283.41
+;; 1-syntax.watsup:277.1-277.38
+syntax unop_vvectype =
+  | _VV(unopVVXX)
+
+;; 1-syntax.watsup:278.1-278.40
+syntax binop_vvectype =
+  | _VV(binopVVXX)
+
+;; 1-syntax.watsup:279.1-279.42
+syntax ternop_vvectype =
+  | _VV(ternopVVXX)
+
+;; 1-syntax.watsup:280.1-280.42
+syntax testop_vvectype =
+  | _VV(testopVVXX)
+
+;; 1-syntax.watsup:282.1-282.43
+syntax shiftop_vectype =
+  | _VI(shiftopVIXX)
+
+;; 1-syntax.watsup:283.1-283.50
+syntax unop_vectype =
+  | _VI(viunop)
+  | _VF(unopVFXX)
+
+;; 1-syntax.watsup:284.1-284.53
+syntax binop_vectype =
+  | _VI(vibinop)
+  | _VF(binopVFXX)
+
+;; 1-syntax.watsup:285.1-285.41
 syntax testop_vectype =
   | _VI(testopVIXX)
 
-;; 1-syntax.watsup:284.1-284.55
+;; 1-syntax.watsup:286.1-286.55
 syntax relop_vectype =
   | _VI(relopVIXX)
   | _VF(relopVFXX)
 
-;; 1-syntax.watsup:285.1-285.73
+;; 1-syntax.watsup:287.1-287.73
 syntax cvtop_vectype =
   | EXTEND
   | TRUNC_SAT
@@ -20178,32 +20253,32 @@ syntax cvtop_vectype =
   | DEMOTE
   | PROMOTE
 
-;; 1-syntax.watsup:303.1-303.68
+;; 1-syntax.watsup:305.1-305.68
 syntax memop = {ALIGN u32, OFFSET u32}
 
-;; 1-syntax.watsup:313.1-313.15
+;; 1-syntax.watsup:315.1-315.15
 syntax c = nat
 
-;; 1-syntax.watsup:314.1-314.23
+;; 1-syntax.watsup:316.1-316.23
 syntax c_numtype = nat
 
-;; 1-syntax.watsup:315.1-315.23
+;; 1-syntax.watsup:317.1-317.23
 syntax c_vectype = nat
 
-;; 1-syntax.watsup:318.1-320.17
+;; 1-syntax.watsup:320.1-322.17
 syntax blocktype =
   | _RESULT(valtype?)
   | _IDX(funcidx)
 
-;; 1-syntax.watsup:361.1-361.27
+;; 1-syntax.watsup:363.1-363.27
 syntax half =
   | LOW
   | HIGH
 
-;; 1-syntax.watsup:359.1-359.45
+;; 1-syntax.watsup:361.1-361.45
 syntax lanesize = nat
 
-;; 1-syntax.watsup:358.1-358.64
+;; 1-syntax.watsup:360.1-360.64
 syntax lanetype =
   | I8
   | I16
@@ -20222,25 +20297,25 @@ def lanetype_packedtype : packedtype -> lanetype
   def lanetype_packedtype(I8_packedtype) = I8_lanetype
   def lanetype_packedtype(I16_packedtype) = I16_lanetype
 
-;; 1-syntax.watsup:360.1-360.54
+;; 1-syntax.watsup:362.1-362.54
 syntax shape = `%X%`(lanetype, lanesize)
 
-;; 1-syntax.watsup:450.1-450.29
+;; 1-syntax.watsup:452.1-452.29
 syntax packshape = `%X%`(nat, nat)
 
-;; 1-syntax.watsup:451.1-454.44
+;; 1-syntax.watsup:453.1-456.44
 syntax vloadop =
   | SHAPE(packshape, sx)
   | SPLAT(nat)
   | ZERO(nat)
 
-;; 1-syntax.watsup:362.1-362.20
+;; 1-syntax.watsup:364.1-364.20
 syntax zero = `ZERO%?`(()?)
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 rec {
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 syntax instr =
   | UNREACHABLE
   | NOP
@@ -20345,61 +20420,61 @@ syntax instr =
   | VSTORE_LANE(n, memidx, memop, laneidx)
 }
 
-;; 1-syntax.watsup:470.1-471.9
+;; 1-syntax.watsup:472.1-473.9
 syntax expr = instr*
 
-;; 1-syntax.watsup:483.1-483.61
+;; 1-syntax.watsup:485.1-485.61
 syntax elemmode =
   | ACTIVE(tableidx, expr)
   | PASSIVE
   | DECLARE
 
-;; 1-syntax.watsup:484.1-484.49
+;; 1-syntax.watsup:486.1-486.49
 syntax datamode =
   | ACTIVE(memidx, expr)
   | PASSIVE
 
-;; 1-syntax.watsup:486.1-487.15
+;; 1-syntax.watsup:488.1-489.15
 syntax type = TYPE(rectype)
 
-;; 1-syntax.watsup:488.1-489.16
+;; 1-syntax.watsup:490.1-491.16
 syntax local = LOCAL(valtype)
 
-;; 1-syntax.watsup:490.1-491.27
+;; 1-syntax.watsup:492.1-493.27
 syntax func = `FUNC%%*%`(typeidx, local*, expr)
 
-;; 1-syntax.watsup:492.1-493.25
+;; 1-syntax.watsup:494.1-495.25
 syntax global = GLOBAL(globaltype, expr)
 
-;; 1-syntax.watsup:494.1-495.23
+;; 1-syntax.watsup:496.1-497.23
 syntax table = TABLE(tabletype, expr)
 
-;; 1-syntax.watsup:496.1-497.17
+;; 1-syntax.watsup:498.1-499.17
 syntax mem = MEMORY(memtype)
 
-;; 1-syntax.watsup:498.1-499.30
+;; 1-syntax.watsup:500.1-501.30
 syntax elem = `ELEM%%*%`(reftype, expr*, elemmode)
 
-;; 1-syntax.watsup:500.1-501.22
+;; 1-syntax.watsup:502.1-503.22
 syntax data = `DATA%*%`(byte*, datamode)
 
-;; 1-syntax.watsup:502.1-503.16
+;; 1-syntax.watsup:504.1-505.16
 syntax start = START(funcidx)
 
-;; 1-syntax.watsup:505.1-506.66
+;; 1-syntax.watsup:507.1-508.66
 syntax externidx =
   | FUNC(funcidx)
   | GLOBAL(globalidx)
   | TABLE(tableidx)
   | MEM(memidx)
 
-;; 1-syntax.watsup:507.1-508.24
+;; 1-syntax.watsup:509.1-510.24
 syntax export = EXPORT(name, externidx)
 
-;; 1-syntax.watsup:509.1-510.30
+;; 1-syntax.watsup:511.1-512.30
 syntax import = IMPORT(name, name, externtype)
 
-;; 1-syntax.watsup:512.1-513.76
+;; 1-syntax.watsup:514.1-515.76
 syntax module = `MODULE%*%*%*%*%*%*%*%*%*%*`(type*, import*, func*, global*, table*, mem*, elem*, data*, start*, export*)
 
 ;; 2-syntax-aux.watsup:8.1-8.33
@@ -25054,50 +25129,65 @@ syntax binopVFXX =
   | PMIN
   | PMAX
 
-;; 1-syntax.watsup:275.1-275.38
-syntax unop_vvectype =
-  | _VV(unopVVXX)
-
-;; 1-syntax.watsup:276.1-276.40
-syntax binop_vvectype =
-  | _VV(binopVVXX)
-
-;; 1-syntax.watsup:277.1-277.42
-syntax ternop_vvectype =
-  | _VV(ternopVVXX)
-
-;; 1-syntax.watsup:278.1-278.42
-syntax testop_vvectype =
-  | _VV(testopVVXX)
-
-;; 1-syntax.watsup:280.1-280.43
-syntax shiftop_vectype =
-  | _VI(shiftopVIXX)
-
-;; 1-syntax.watsup:281.1-281.61
-syntax unop_vectype =
-  | _VI(unopVIXX)
-  | _VF(unopVFXX)
+;; 1-syntax.watsup:274.1-274.36
+syntax viunop =
+  | ABS
+  | NEG
   | POPCNT
 
-;; 1-syntax.watsup:282.1-282.112
-syntax binop_vectype =
-  | _VI(binopVIXX, minmaxopVIXX, satbinopVIXX)
-  | _VF(binopVFXX)
+;; 1-syntax.watsup:275.1-275.90
+syntax vibinop =
+  | ADD
+  | SUB
+  | SWIZZLE
+  | MIN(sx)
+  | MAX(sx)
+  | ADD_SAT(sx)
+  | SUB_SAT(sx)
   | MUL
   | AVGR_U
   | Q15MULR_SAT_S
 
-;; 1-syntax.watsup:283.1-283.41
+;; 1-syntax.watsup:277.1-277.38
+syntax unop_vvectype =
+  | _VV(unopVVXX)
+
+;; 1-syntax.watsup:278.1-278.40
+syntax binop_vvectype =
+  | _VV(binopVVXX)
+
+;; 1-syntax.watsup:279.1-279.42
+syntax ternop_vvectype =
+  | _VV(ternopVVXX)
+
+;; 1-syntax.watsup:280.1-280.42
+syntax testop_vvectype =
+  | _VV(testopVVXX)
+
+;; 1-syntax.watsup:282.1-282.43
+syntax shiftop_vectype =
+  | _VI(shiftopVIXX)
+
+;; 1-syntax.watsup:283.1-283.50
+syntax unop_vectype =
+  | _VI(viunop)
+  | _VF(unopVFXX)
+
+;; 1-syntax.watsup:284.1-284.53
+syntax binop_vectype =
+  | _VI(vibinop)
+  | _VF(binopVFXX)
+
+;; 1-syntax.watsup:285.1-285.41
 syntax testop_vectype =
   | _VI(testopVIXX)
 
-;; 1-syntax.watsup:284.1-284.55
+;; 1-syntax.watsup:286.1-286.55
 syntax relop_vectype =
   | _VI(relopVIXX)
   | _VF(relopVFXX)
 
-;; 1-syntax.watsup:285.1-285.73
+;; 1-syntax.watsup:287.1-287.73
 syntax cvtop_vectype =
   | EXTEND
   | TRUNC_SAT
@@ -25105,32 +25195,32 @@ syntax cvtop_vectype =
   | DEMOTE
   | PROMOTE
 
-;; 1-syntax.watsup:303.1-303.68
+;; 1-syntax.watsup:305.1-305.68
 syntax memop = {ALIGN u32, OFFSET u32}
 
-;; 1-syntax.watsup:313.1-313.15
+;; 1-syntax.watsup:315.1-315.15
 syntax c = nat
 
-;; 1-syntax.watsup:314.1-314.23
+;; 1-syntax.watsup:316.1-316.23
 syntax c_numtype = nat
 
-;; 1-syntax.watsup:315.1-315.23
+;; 1-syntax.watsup:317.1-317.23
 syntax c_vectype = nat
 
-;; 1-syntax.watsup:318.1-320.17
+;; 1-syntax.watsup:320.1-322.17
 syntax blocktype =
   | _RESULT(valtype?)
   | _IDX(funcidx)
 
-;; 1-syntax.watsup:361.1-361.27
+;; 1-syntax.watsup:363.1-363.27
 syntax half =
   | LOW
   | HIGH
 
-;; 1-syntax.watsup:359.1-359.45
+;; 1-syntax.watsup:361.1-361.45
 syntax lanesize = nat
 
-;; 1-syntax.watsup:358.1-358.64
+;; 1-syntax.watsup:360.1-360.64
 syntax lanetype =
   | I8
   | I16
@@ -25149,25 +25239,25 @@ def lanetype_packedtype : packedtype -> lanetype
   def lanetype_packedtype(I8_packedtype) = I8_lanetype
   def lanetype_packedtype(I16_packedtype) = I16_lanetype
 
-;; 1-syntax.watsup:360.1-360.54
+;; 1-syntax.watsup:362.1-362.54
 syntax shape = `%X%`(lanetype, lanesize)
 
-;; 1-syntax.watsup:450.1-450.29
+;; 1-syntax.watsup:452.1-452.29
 syntax packshape = `%X%`(nat, nat)
 
-;; 1-syntax.watsup:451.1-454.44
+;; 1-syntax.watsup:453.1-456.44
 syntax vloadop =
   | SHAPE(packshape, sx)
   | SPLAT(nat)
   | ZERO(nat)
 
-;; 1-syntax.watsup:362.1-362.20
+;; 1-syntax.watsup:364.1-364.20
 syntax zero = `ZERO%?`(()?)
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 rec {
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 syntax instr =
   | UNREACHABLE
   | NOP
@@ -25272,61 +25362,61 @@ syntax instr =
   | VSTORE_LANE(n, memidx, memop, laneidx)
 }
 
-;; 1-syntax.watsup:470.1-471.9
+;; 1-syntax.watsup:472.1-473.9
 syntax expr = instr*
 
-;; 1-syntax.watsup:483.1-483.61
+;; 1-syntax.watsup:485.1-485.61
 syntax elemmode =
   | ACTIVE(tableidx, expr)
   | PASSIVE
   | DECLARE
 
-;; 1-syntax.watsup:484.1-484.49
+;; 1-syntax.watsup:486.1-486.49
 syntax datamode =
   | ACTIVE(memidx, expr)
   | PASSIVE
 
-;; 1-syntax.watsup:486.1-487.15
+;; 1-syntax.watsup:488.1-489.15
 syntax type = TYPE(rectype)
 
-;; 1-syntax.watsup:488.1-489.16
+;; 1-syntax.watsup:490.1-491.16
 syntax local = LOCAL(valtype)
 
-;; 1-syntax.watsup:490.1-491.27
+;; 1-syntax.watsup:492.1-493.27
 syntax func = `FUNC%%*%`(typeidx, local*, expr)
 
-;; 1-syntax.watsup:492.1-493.25
+;; 1-syntax.watsup:494.1-495.25
 syntax global = GLOBAL(globaltype, expr)
 
-;; 1-syntax.watsup:494.1-495.23
+;; 1-syntax.watsup:496.1-497.23
 syntax table = TABLE(tabletype, expr)
 
-;; 1-syntax.watsup:496.1-497.17
+;; 1-syntax.watsup:498.1-499.17
 syntax mem = MEMORY(memtype)
 
-;; 1-syntax.watsup:498.1-499.30
+;; 1-syntax.watsup:500.1-501.30
 syntax elem = `ELEM%%*%`(reftype, expr*, elemmode)
 
-;; 1-syntax.watsup:500.1-501.22
+;; 1-syntax.watsup:502.1-503.22
 syntax data = `DATA%*%`(byte*, datamode)
 
-;; 1-syntax.watsup:502.1-503.16
+;; 1-syntax.watsup:504.1-505.16
 syntax start = START(funcidx)
 
-;; 1-syntax.watsup:505.1-506.66
+;; 1-syntax.watsup:507.1-508.66
 syntax externidx =
   | FUNC(funcidx)
   | GLOBAL(globalidx)
   | TABLE(tableidx)
   | MEM(memidx)
 
-;; 1-syntax.watsup:507.1-508.24
+;; 1-syntax.watsup:509.1-510.24
 syntax export = EXPORT(name, externidx)
 
-;; 1-syntax.watsup:509.1-510.30
+;; 1-syntax.watsup:511.1-512.30
 syntax import = IMPORT(name, name, externtype)
 
-;; 1-syntax.watsup:512.1-513.76
+;; 1-syntax.watsup:514.1-515.76
 syntax module = `MODULE%*%*%*%*%*%*%*%*%*%*`(type*, import*, func*, global*, table*, mem*, elem*, data*, start*, export*)
 
 ;; 2-syntax-aux.watsup:8.1-8.33
@@ -30135,50 +30225,65 @@ syntax binopVFXX =
   | PMIN
   | PMAX
 
-;; 1-syntax.watsup:275.1-275.38
-syntax unop_vvectype =
-  | _VV(unopVVXX)
-
-;; 1-syntax.watsup:276.1-276.40
-syntax binop_vvectype =
-  | _VV(binopVVXX)
-
-;; 1-syntax.watsup:277.1-277.42
-syntax ternop_vvectype =
-  | _VV(ternopVVXX)
-
-;; 1-syntax.watsup:278.1-278.42
-syntax testop_vvectype =
-  | _VV(testopVVXX)
-
-;; 1-syntax.watsup:280.1-280.43
-syntax shiftop_vectype =
-  | _VI(shiftopVIXX)
-
-;; 1-syntax.watsup:281.1-281.61
-syntax unop_vectype =
-  | _VI(unopVIXX)
-  | _VF(unopVFXX)
+;; 1-syntax.watsup:274.1-274.36
+syntax viunop =
+  | ABS
+  | NEG
   | POPCNT
 
-;; 1-syntax.watsup:282.1-282.112
-syntax binop_vectype =
-  | _VI(binopVIXX, minmaxopVIXX, satbinopVIXX)
-  | _VF(binopVFXX)
+;; 1-syntax.watsup:275.1-275.90
+syntax vibinop =
+  | ADD
+  | SUB
+  | SWIZZLE
+  | MIN(sx)
+  | MAX(sx)
+  | ADD_SAT(sx)
+  | SUB_SAT(sx)
   | MUL
   | AVGR_U
   | Q15MULR_SAT_S
 
-;; 1-syntax.watsup:283.1-283.41
+;; 1-syntax.watsup:277.1-277.38
+syntax unop_vvectype =
+  | _VV(unopVVXX)
+
+;; 1-syntax.watsup:278.1-278.40
+syntax binop_vvectype =
+  | _VV(binopVVXX)
+
+;; 1-syntax.watsup:279.1-279.42
+syntax ternop_vvectype =
+  | _VV(ternopVVXX)
+
+;; 1-syntax.watsup:280.1-280.42
+syntax testop_vvectype =
+  | _VV(testopVVXX)
+
+;; 1-syntax.watsup:282.1-282.43
+syntax shiftop_vectype =
+  | _VI(shiftopVIXX)
+
+;; 1-syntax.watsup:283.1-283.50
+syntax unop_vectype =
+  | _VI(viunop)
+  | _VF(unopVFXX)
+
+;; 1-syntax.watsup:284.1-284.53
+syntax binop_vectype =
+  | _VI(vibinop)
+  | _VF(binopVFXX)
+
+;; 1-syntax.watsup:285.1-285.41
 syntax testop_vectype =
   | _VI(testopVIXX)
 
-;; 1-syntax.watsup:284.1-284.55
+;; 1-syntax.watsup:286.1-286.55
 syntax relop_vectype =
   | _VI(relopVIXX)
   | _VF(relopVFXX)
 
-;; 1-syntax.watsup:285.1-285.73
+;; 1-syntax.watsup:287.1-287.73
 syntax cvtop_vectype =
   | EXTEND
   | TRUNC_SAT
@@ -30186,32 +30291,32 @@ syntax cvtop_vectype =
   | DEMOTE
   | PROMOTE
 
-;; 1-syntax.watsup:303.1-303.68
+;; 1-syntax.watsup:305.1-305.68
 syntax memop = {ALIGN u32, OFFSET u32}
 
-;; 1-syntax.watsup:313.1-313.15
+;; 1-syntax.watsup:315.1-315.15
 syntax c = nat
 
-;; 1-syntax.watsup:314.1-314.23
+;; 1-syntax.watsup:316.1-316.23
 syntax c_numtype = nat
 
-;; 1-syntax.watsup:315.1-315.23
+;; 1-syntax.watsup:317.1-317.23
 syntax c_vectype = nat
 
-;; 1-syntax.watsup:318.1-320.17
+;; 1-syntax.watsup:320.1-322.17
 syntax blocktype =
   | _RESULT(valtype?)
   | _IDX(funcidx)
 
-;; 1-syntax.watsup:361.1-361.27
+;; 1-syntax.watsup:363.1-363.27
 syntax half =
   | LOW
   | HIGH
 
-;; 1-syntax.watsup:359.1-359.45
+;; 1-syntax.watsup:361.1-361.45
 syntax lanesize = nat
 
-;; 1-syntax.watsup:358.1-358.64
+;; 1-syntax.watsup:360.1-360.64
 syntax lanetype =
   | I8
   | I16
@@ -30230,25 +30335,25 @@ def lanetype_packedtype : packedtype -> lanetype
   def lanetype_packedtype(I8_packedtype) = I8_lanetype
   def lanetype_packedtype(I16_packedtype) = I16_lanetype
 
-;; 1-syntax.watsup:360.1-360.54
+;; 1-syntax.watsup:362.1-362.54
 syntax shape = `%X%`(lanetype, lanesize)
 
-;; 1-syntax.watsup:450.1-450.29
+;; 1-syntax.watsup:452.1-452.29
 syntax packshape = `%X%`(nat, nat)
 
-;; 1-syntax.watsup:451.1-454.44
+;; 1-syntax.watsup:453.1-456.44
 syntax vloadop =
   | SHAPE(packshape, sx)
   | SPLAT(nat)
   | ZERO(nat)
 
-;; 1-syntax.watsup:362.1-362.20
+;; 1-syntax.watsup:364.1-364.20
 syntax zero = `ZERO%?`(()?)
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 rec {
 
-;; 1-syntax.watsup:456.1-468.78
+;; 1-syntax.watsup:458.1-470.78
 syntax instr =
   | UNREACHABLE
   | NOP
@@ -30353,61 +30458,61 @@ syntax instr =
   | VSTORE_LANE(n, memidx, memop, laneidx)
 }
 
-;; 1-syntax.watsup:470.1-471.9
+;; 1-syntax.watsup:472.1-473.9
 syntax expr = instr*
 
-;; 1-syntax.watsup:483.1-483.61
+;; 1-syntax.watsup:485.1-485.61
 syntax elemmode =
   | ACTIVE(tableidx, expr)
   | PASSIVE
   | DECLARE
 
-;; 1-syntax.watsup:484.1-484.49
+;; 1-syntax.watsup:486.1-486.49
 syntax datamode =
   | ACTIVE(memidx, expr)
   | PASSIVE
 
-;; 1-syntax.watsup:486.1-487.15
+;; 1-syntax.watsup:488.1-489.15
 syntax type = TYPE(rectype)
 
-;; 1-syntax.watsup:488.1-489.16
+;; 1-syntax.watsup:490.1-491.16
 syntax local = LOCAL(valtype)
 
-;; 1-syntax.watsup:490.1-491.27
+;; 1-syntax.watsup:492.1-493.27
 syntax func = `FUNC%%*%`(typeidx, local*, expr)
 
-;; 1-syntax.watsup:492.1-493.25
+;; 1-syntax.watsup:494.1-495.25
 syntax global = GLOBAL(globaltype, expr)
 
-;; 1-syntax.watsup:494.1-495.23
+;; 1-syntax.watsup:496.1-497.23
 syntax table = TABLE(tabletype, expr)
 
-;; 1-syntax.watsup:496.1-497.17
+;; 1-syntax.watsup:498.1-499.17
 syntax mem = MEMORY(memtype)
 
-;; 1-syntax.watsup:498.1-499.30
+;; 1-syntax.watsup:500.1-501.30
 syntax elem = `ELEM%%*%`(reftype, expr*, elemmode)
 
-;; 1-syntax.watsup:500.1-501.22
+;; 1-syntax.watsup:502.1-503.22
 syntax data = `DATA%*%`(byte*, datamode)
 
-;; 1-syntax.watsup:502.1-503.16
+;; 1-syntax.watsup:504.1-505.16
 syntax start = START(funcidx)
 
-;; 1-syntax.watsup:505.1-506.66
+;; 1-syntax.watsup:507.1-508.66
 syntax externidx =
   | FUNC(funcidx)
   | GLOBAL(globalidx)
   | TABLE(tableidx)
   | MEM(memidx)
 
-;; 1-syntax.watsup:507.1-508.24
+;; 1-syntax.watsup:509.1-510.24
 syntax export = EXPORT(name, externidx)
 
-;; 1-syntax.watsup:509.1-510.30
+;; 1-syntax.watsup:511.1-512.30
 syntax import = IMPORT(name, name, externtype)
 
-;; 1-syntax.watsup:512.1-513.76
+;; 1-syntax.watsup:514.1-515.76
 syntax module = `MODULE%*%*%*%*%*%*%*%*%*%*`(type*, import*, func*, global*, table*, mem*, elem*, data*, start*, export*)
 
 ;; 2-syntax-aux.watsup:8.1-8.33

--- a/spectec/test-splice/TEST.md
+++ b/spectec/test-splice/TEST.md
@@ -670,6 +670,8 @@ warning: syntax `valtype` was never spliced
 warning: syntax `valtype` was never spliced
 warning: syntax `vec` was never spliced
 warning: syntax `vectype` was never spliced
+warning: syntax `vibinop` was never spliced
+warning: syntax `viunop` was never spliced
 warning: syntax `vloadop` was never spliced
 warning: syntax `zero` was never spliced
 warning: grammar `Babsheaptype` was never spliced


### PR DESCRIPTION
### Context
```
syntax binop_numtype = | _I ibinop | _F fbinop
```
Most operations are wrapped with some case. For example, `binop_numtype` is wrapped with either `_I` or `_F`, and I think this wrapper indicates the type of the operation: either integer operation or float operation

### Problem
```
syntax binopVIXX = | ADD | SUB | SWIZZLE
syntax minmaxopVIXX = | MIN sx | MAX sx
syntax satbinopVIXX = | ADD_SAT sx | SUB_SAT sx
syntax binopVFXX = | ADD | SUB | MUL | DIV | MIN | MAX | PMIN | PMAX
syntax binop_vectype = | _VI binopVIXX minmaxopVIXX satbinopVIXX | _VF binopVFXX | MUL | AVGR_U | Q15MULR_SAT_S
```
(Note: There is a typo in the current syntax; `_VI binopVIXX minmaxopVIXX satbinopVIXX` may means something like `_VI (binopVIXX | minmaxopVIXX | satbinopVIXX)`)
However, some vector operation is not wrapped. For example, `MUL`, `AVGR_U`, and `Q15MULR_SAT_S` in `binop_vectype` are not wrapped, but I think they are also vector operation of integer. That is, it should be wrapped with `_VI`.

### Solution
```
syntax binopVIXX = | ADD | SUB | SWIZZLE
syntax minmaxopVIXX = | MIN sx | MAX sx
syntax satbinopVIXX = | ADD_SAT sx | SUB_SAT sx
syntax vibinop = | binopVIXX | minmaxopVIXX | satbinopVIXX | MUL | AVGR_U | Q15MULR_SAT_S
syntax binopVFXX = | ADD | SUB | MUL | DIV | MIN | MAX | PMIN | PMAX
syntax binop_vectype = | _VI vibinop | _VF binopVFXX
```
This is what I want to do.

```
syntax binopVIXX = | ADD | SUB | SWIZZLE | MIN sx | ... | MAX | AVGR_U | Q15MULR_SAT_S
syntax binopVFXX = | ADD | SUB | MUL | DIV | MIN | MAX | PMIN | PMAX
syntax binop_vectype = | _VI binopVIXX | _VF binopVFXX
```
There could be another option: inlining all of them.

I think both options seems to be fine. Do you have any preference or idea?

Thanks!