### PR TITLE
Removing duplicate prose

### DIFF
--- a/spectec/spec/wasm-1.0/6-typing.watsup
+++ b/spectec/spec/wasm-1.0/6-typing.watsup
@@ -223,17 +223,17 @@ rule Instr_ok/relop:
   C |- RELOP t relop : t t -> I32
 
 
-rule Instr_ok/reinterpret:
-  C |- CVTOP t_1 REINTERPRET t_2 : t_2 -> t_1
-  -- if t_1 =/= t_2
-  -- if $size(t_1) = $size(t_2)
+rule Instr_ok/cvtop-reinterpret:
+  C |- CVTOP nt_1 REINTERPRET nt_2 : nt_2 -> nt_1
+  -- if nt_1 =/= nt_2
+  -- if $size(nt_1) = $size(nt_2)
 
-rule Instr_ok/convert-i:
+rule Instr_ok/cvtop-convert-i:
   C |- CVTOP inn_1 CONVERT inn_2 sx? : inn_2 -> inn_1
   -- if inn_1 =/= inn_2
   -- if sx? = eps <=> $size(inn_1) > $size(inn_2)
 
-rule Instr_ok/convert-f:
+rule Instr_ok/cvtop-convert-f:
   C |- CVTOP fnn_1 CONVERT fnn_2 : fnn_2 -> fnn_1
   -- if fnn_1 =/= fnn_2
 

--- a/spectec/spec/wasm-2.0/6-typing.watsup
+++ b/spectec/spec/wasm-2.0/6-typing.watsup
@@ -273,17 +273,17 @@ rule Instr_ok/extend:
   C |- EXTEND nt n : nt -> nt
   -- if n <= $size(nt)
 
-rule Instr_ok/reinterpret:
+rule Instr_ok/cvtop-reinterpret:
   C |- CVTOP nt_1 REINTERPRET nt_2 : nt_2 -> nt_1
   -- if nt_1 =/= nt_2
   -- if $size(nt_1) = $size(nt_2)
 
-rule Instr_ok/convert-i:
+rule Instr_ok/cvtop-convert-i:
   C |- CVTOP inn_1 CONVERT inn_2 sx? : inn_2 -> inn_1
   -- if inn_1 =/= inn_2
   -- if sx? = eps <=> $size(inn_1) > $size(inn_2)
 
-rule Instr_ok/convert-f:
+rule Instr_ok/cvtop-convert-f:
   C |- CVTOP fnn_1 CONVERT fnn_2 : fnn_2 -> fnn_1
   -- if fnn_1 =/= fnn_2
 

--- a/spectec/spec/wasm-3.0/6-typing.watsup
+++ b/spectec/spec/wasm-3.0/6-typing.watsup
@@ -697,17 +697,17 @@ rule Instr_ok/extend:
   C |- EXTEND nt n : nt -> nt
   -- if n <= $size(nt)
 
-rule Instr_ok/reinterpret:
+rule Instr_ok/cvtop-reinterpret:
   C |- CVTOP nt_1 REINTERPRET nt_2 : nt_2 -> nt_1
   -- if nt_1 =/= nt_2
   -- if $size(nt_1) = $size(nt_2)
 
-rule Instr_ok/convert-i:
+rule Instr_ok/cvtop-convert-i:
   C |- CVTOP inn_1 CONVERT inn_2 sx? : inn_2 -> inn_1
   -- if inn_1 =/= inn_2
   -- if sx? = eps <=> $size(inn_1) > $size(inn_2)
 
-rule Instr_ok/convert-f:
+rule Instr_ok/cvtop-convert-f:
   C |- CVTOP fnn_1 CONVERT fnn_2 : fnn_2 -> fnn_1
   -- if fnn_1 =/= fnn_2
 

--- a/spectec/src/exe-watsup/main.ml
+++ b/spectec/src/exe-watsup/main.ml
@@ -194,7 +194,20 @@ let () =
     let al =
       if !target = Check || not (PS.mem Animate !selected_passes) then [] else (
         log "Translating to AL...";
-        (Il2al.Translate.translate il @ Backend_interpreter.Manual.manual_algos)
+        let get_name = function
+          | Al.Ast.RuleA ((id, _), _, _) -> id
+          | Al.Ast.FuncA (id, _, _) -> id
+        in
+        let al_manual = Backend_interpreter.Manual.manual_algos in
+        let names_manual = List.map get_name al_manual in
+        let al_translated =
+          List.filter
+            (fun algo ->
+              let name_translated = get_name algo in
+              not (List.mem name_translated names_manual))
+            (Il2al.Translate.translate il)
+        in
+        al_translated @ al_manual
       )
     in
 

--- a/spectec/test-frontend/TEST.md
+++ b/spectec/test-frontend/TEST.md
@@ -2764,19 +2764,19 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if (n <= $size(nt <: valtype))
 
   ;; 6-typing.watsup:700.1-703.34
-  rule reinterpret {C : context, nt_1 : numtype, nt_2 : numtype}:
+  rule cvtop-reinterpret {C : context, nt_1 : numtype, nt_2 : numtype}:
     `%|-%:%`(C, CVTOP_instr(nt_1, REINTERPRET_cvtop, nt_2, ?()), `%->%`([(nt_2 <: valtype)], [(nt_1 <: valtype)]))
     -- if (nt_1 =/= nt_2)
     -- if ($size(nt_1 <: valtype) = $size(nt_2 <: valtype))
 
   ;; 6-typing.watsup:705.1-708.50
-  rule convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?}:
+  rule cvtop-convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?}:
     `%|-%:%`(C, CVTOP_instr((inn_1 <: numtype), CONVERT_cvtop, (inn_2 <: numtype), sx?{sx}), `%->%`([(inn_2 <: valtype)], [(inn_1 <: valtype)]))
     -- if (inn_1 =/= inn_2)
     -- if ((sx?{sx} = ?()) <=> ($size(inn_1 <: valtype) > $size(inn_2 <: valtype)))
 
   ;; 6-typing.watsup:710.1-712.24
-  rule convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
+  rule cvtop-convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
     `%|-%:%`(C, CVTOP_instr((fnn_1 <: numtype), CONVERT_cvtop, (fnn_2 <: numtype), ?()), `%->%`([(fnn_2 <: valtype)], [(fnn_1 <: valtype)]))
     -- if (fnn_1 =/= fnn_2)
 

--- a/spectec/test-latex/TEST.md
+++ b/spectec/test-latex/TEST.md
@@ -3030,7 +3030,7 @@ $$
 {|{\mathit{nt}}_{{1}}|} = {|{\mathit{nt}}_{{2}}|}
 }{
 {\mathit{C}} \vdash \mathsf{cvtop}~{\mathit{nt}}_{{1}}~\mathsf{reinterpret}~{\mathit{nt}}_{{2}} : {\mathit{nt}}_{{2}} \rightarrow {\mathit{nt}}_{{1}}
-} \, {[\textsc{\scriptsize T{-}reinterpret}]}
+} \, {[\textsc{\scriptsize T{-}cvtop{-}reinterpret}]}
 \qquad
 \end{array}
 $$
@@ -3043,7 +3043,7 @@ $$
 {{\mathit{sx}}^?} = \epsilon \Leftrightarrow {|{{\mathsf{i}}{{\mathit{n}}}}_{{1}}|} > {|{{\mathsf{i}}{{\mathit{n}}}}_{{2}}|}
 }{
 {\mathit{C}} \vdash {{\mathsf{i}}{{\mathit{n}}}}_{{1}} . {{{{\mathsf{convert}}{\mathsf{\_}}}{{{\mathsf{i}}{{\mathit{n}}}}_{{2}}}}{\mathsf{\_}}}{{{\mathit{sx}}^?}} : {{\mathsf{i}}{{\mathit{n}}}}_{{2}} \rightarrow {{\mathsf{i}}{{\mathit{n}}}}_{{1}}
-} \, {[\textsc{\scriptsize T{-}convert{-}i}]}
+} \, {[\textsc{\scriptsize T{-}cvtop{-}convert{-}i}]}
 \qquad
 \end{array}
 $$
@@ -3054,7 +3054,7 @@ $$
 {{\mathsf{f}}{{\mathit{n}}}}_{{1}} \neq {{\mathsf{f}}{{\mathit{n}}}}_{{2}}
 }{
 {\mathit{C}} \vdash \mathsf{cvtop}~{{\mathsf{f}}{{\mathit{n}}}}_{{1}}~\mathsf{convert}~{{\mathsf{f}}{{\mathit{n}}}}_{{2}} : {{\mathsf{f}}{{\mathit{n}}}}_{{2}} \rightarrow {{\mathsf{f}}{{\mathit{n}}}}_{{1}}
-} \, {[\textsc{\scriptsize T{-}convert{-}f}]}
+} \, {[\textsc{\scriptsize T{-}cvtop{-}convert{-}f}]}
 \qquad
 \end{array}
 $$

--- a/spectec/test-middlend/TEST.md
+++ b/spectec/test-middlend/TEST.md
@@ -2627,19 +2627,19 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if (n <= $size(nt <: valtype))
 
   ;; 6-typing.watsup:700.1-703.34
-  rule reinterpret {C : context, nt_1 : numtype, nt_2 : numtype}:
+  rule cvtop-reinterpret {C : context, nt_1 : numtype, nt_2 : numtype}:
     `%|-%:%`(C, CVTOP_instr(nt_1, REINTERPRET_cvtop, nt_2, ?()), `%->%`([(nt_2 <: valtype)], [(nt_1 <: valtype)]))
     -- if (nt_1 =/= nt_2)
     -- if ($size(nt_1 <: valtype) = $size(nt_2 <: valtype))
 
   ;; 6-typing.watsup:705.1-708.50
-  rule convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?}:
+  rule cvtop-convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?}:
     `%|-%:%`(C, CVTOP_instr((inn_1 <: numtype), CONVERT_cvtop, (inn_2 <: numtype), sx?{sx}), `%->%`([(inn_2 <: valtype)], [(inn_1 <: valtype)]))
     -- if (inn_1 =/= inn_2)
     -- if ((sx?{sx} = ?()) <=> ($size(inn_1 <: valtype) > $size(inn_2 <: valtype)))
 
   ;; 6-typing.watsup:710.1-712.24
-  rule convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
+  rule cvtop-convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
     `%|-%:%`(C, CVTOP_instr((fnn_1 <: numtype), CONVERT_cvtop, (fnn_2 <: numtype), ?()), `%->%`([(fnn_2 <: valtype)], [(fnn_1 <: valtype)]))
     -- if (fnn_1 =/= fnn_2)
 
@@ -7551,19 +7551,19 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if (n <= $size($valtype_numtype(nt)))
 
   ;; 6-typing.watsup:700.1-703.34
-  rule reinterpret {C : context, nt_1 : numtype, nt_2 : numtype}:
+  rule cvtop-reinterpret {C : context, nt_1 : numtype, nt_2 : numtype}:
     `%|-%:%`(C, CVTOP_instr(nt_1, REINTERPRET_cvtop, nt_2, ?()), `%->%`([$valtype_numtype(nt_2)], [$valtype_numtype(nt_1)]))
     -- if (nt_1 =/= nt_2)
     -- if ($size($valtype_numtype(nt_1)) = $size($valtype_numtype(nt_2)))
 
   ;; 6-typing.watsup:705.1-708.50
-  rule convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?}:
+  rule cvtop-convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?}:
     `%|-%:%`(C, CVTOP_instr($numtype_inn(inn_1), CONVERT_cvtop, $numtype_inn(inn_2), sx?{sx}), `%->%`([$valtype_inn(inn_2)], [$valtype_inn(inn_1)]))
     -- if (inn_1 =/= inn_2)
     -- if ((sx?{sx} = ?()) <=> ($size($valtype_inn(inn_1)) > $size($valtype_inn(inn_2))))
 
   ;; 6-typing.watsup:710.1-712.24
-  rule convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
+  rule cvtop-convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
     `%|-%:%`(C, CVTOP_instr($numtype_fnn(fnn_1), CONVERT_cvtop, $numtype_fnn(fnn_2), ?()), `%->%`([$valtype_fnn(fnn_2)], [$valtype_fnn(fnn_1)]))
     -- if (fnn_1 =/= fnn_2)
 
@@ -12478,19 +12478,19 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if (n <= !($size($valtype_numtype(nt))))
 
   ;; 6-typing.watsup:700.1-703.34
-  rule reinterpret {C : context, nt_1 : numtype, nt_2 : numtype}:
+  rule cvtop-reinterpret {C : context, nt_1 : numtype, nt_2 : numtype}:
     `%|-%:%`(C, CVTOP_instr(nt_1, REINTERPRET_cvtop, nt_2, ?()), `%->%`([$valtype_numtype(nt_2)], [$valtype_numtype(nt_1)]))
     -- if (nt_1 =/= nt_2)
     -- if (!($size($valtype_numtype(nt_1))) = !($size($valtype_numtype(nt_2))))
 
   ;; 6-typing.watsup:705.1-708.50
-  rule convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?}:
+  rule cvtop-convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?}:
     `%|-%:%`(C, CVTOP_instr($numtype_inn(inn_1), CONVERT_cvtop, $numtype_inn(inn_2), sx?{sx}), `%->%`([$valtype_inn(inn_2)], [$valtype_inn(inn_1)]))
     -- if (inn_1 =/= inn_2)
     -- if ((sx?{sx} = ?()) <=> (!($size($valtype_inn(inn_1))) > !($size($valtype_inn(inn_2)))))
 
   ;; 6-typing.watsup:710.1-712.24
-  rule convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
+  rule cvtop-convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
     `%|-%:%`(C, CVTOP_instr($numtype_fnn(fnn_1), CONVERT_cvtop, $numtype_fnn(fnn_2), ?()), `%->%`([$valtype_fnn(fnn_2)], [$valtype_fnn(fnn_1)]))
     -- if (fnn_1 =/= fnn_2)
 
@@ -17406,7 +17406,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if (n <= o0)
 
   ;; 6-typing.watsup:700.1-703.34
-  rule reinterpret {C : context, nt_1 : numtype, nt_2 : numtype, o0 : nat, o1 : nat}:
+  rule cvtop-reinterpret {C : context, nt_1 : numtype, nt_2 : numtype, o0 : nat, o1 : nat}:
     `%|-%:%`(C, CVTOP_instr(nt_1, REINTERPRET_cvtop, nt_2, ?()), `%->%`([$valtype_numtype(nt_2)], [$valtype_numtype(nt_1)]))
     -- if ($size($valtype_numtype(nt_1)) = ?(o0))
     -- if ($size($valtype_numtype(nt_2)) = ?(o1))
@@ -17414,7 +17414,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if (o0 = o1)
 
   ;; 6-typing.watsup:705.1-708.50
-  rule convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?, o0 : nat, o1 : nat}:
+  rule cvtop-convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?, o0 : nat, o1 : nat}:
     `%|-%:%`(C, CVTOP_instr($numtype_inn(inn_1), CONVERT_cvtop, $numtype_inn(inn_2), sx?{sx}), `%->%`([$valtype_inn(inn_2)], [$valtype_inn(inn_1)]))
     -- if ($size($valtype_inn(inn_1)) = ?(o0))
     -- if ($size($valtype_inn(inn_2)) = ?(o1))
@@ -17422,7 +17422,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if ((sx?{sx} = ?()) <=> (o0 > o1))
 
   ;; 6-typing.watsup:710.1-712.24
-  rule convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
+  rule cvtop-convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
     `%|-%:%`(C, CVTOP_instr($numtype_fnn(fnn_1), CONVERT_cvtop, $numtype_fnn(fnn_2), ?()), `%->%`([$valtype_fnn(fnn_2)], [$valtype_fnn(fnn_1)]))
     -- if (fnn_1 =/= fnn_2)
 
@@ -22358,7 +22358,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if (n <= o0)
 
   ;; 6-typing.watsup:700.1-703.34
-  rule reinterpret {C : context, nt_1 : numtype, nt_2 : numtype, o0 : nat, o1 : nat}:
+  rule cvtop-reinterpret {C : context, nt_1 : numtype, nt_2 : numtype, o0 : nat, o1 : nat}:
     `%|-%:%`(C, CVTOP_instr(nt_1, REINTERPRET_cvtop, nt_2, ?()), `%->%`([$valtype_numtype(nt_2)], [$valtype_numtype(nt_1)]))
     -- if ($size($valtype_numtype(nt_1)) = ?(o0))
     -- if ($size($valtype_numtype(nt_2)) = ?(o1))
@@ -22366,7 +22366,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if (o0 = o1)
 
   ;; 6-typing.watsup:705.1-708.50
-  rule convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?, o0 : nat, o1 : nat}:
+  rule cvtop-convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?, o0 : nat, o1 : nat}:
     `%|-%:%`(C, CVTOP_instr($numtype_inn(inn_1), CONVERT_cvtop, $numtype_inn(inn_2), sx?{sx}), `%->%`([$valtype_inn(inn_2)], [$valtype_inn(inn_1)]))
     -- if ($size($valtype_inn(inn_1)) = ?(o0))
     -- if ($size($valtype_inn(inn_2)) = ?(o1))
@@ -22374,7 +22374,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if ((sx?{sx} = ?()) <=> (o0 > o1))
 
   ;; 6-typing.watsup:710.1-712.24
-  rule convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
+  rule cvtop-convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
     `%|-%:%`(C, CVTOP_instr($numtype_fnn(fnn_1), CONVERT_cvtop, $numtype_fnn(fnn_2), ?()), `%->%`([$valtype_fnn(fnn_2)], [$valtype_fnn(fnn_1)]))
     -- if (fnn_1 =/= fnn_2)
 
@@ -27343,7 +27343,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if (n <= o0)
 
   ;; 6-typing.watsup:700.1-703.34
-  rule reinterpret {C : context, nt_1 : numtype, nt_2 : numtype, o0 : nat, o1 : nat}:
+  rule cvtop-reinterpret {C : context, nt_1 : numtype, nt_2 : numtype, o0 : nat, o1 : nat}:
     `%|-%:%`(C, CVTOP_instr(nt_1, REINTERPRET_cvtop, nt_2, ?()), `%->%`([$valtype_numtype(nt_2)], [$valtype_numtype(nt_1)]))
     -- if ($size($valtype_numtype(nt_1)) = ?(o0))
     -- if ($size($valtype_numtype(nt_2)) = ?(o1))
@@ -27351,7 +27351,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if (o0 = o1)
 
   ;; 6-typing.watsup:705.1-708.50
-  rule convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?, o0 : nat, o1 : nat}:
+  rule cvtop-convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?, o0 : nat, o1 : nat}:
     `%|-%:%`(C, CVTOP_instr($numtype_inn(inn_1), CONVERT_cvtop, $numtype_inn(inn_2), sx?{sx}), `%->%`([$valtype_inn(inn_2)], [$valtype_inn(inn_1)]))
     -- if ($size($valtype_inn(inn_1)) = ?(o0))
     -- if ($size($valtype_inn(inn_2)) = ?(o1))
@@ -27359,7 +27359,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if ((sx?{sx} = ?()) <=> (o0 > o1))
 
   ;; 6-typing.watsup:710.1-712.24
-  rule convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
+  rule cvtop-convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
     `%|-%:%`(C, CVTOP_instr($numtype_fnn(fnn_1), CONVERT_cvtop, $numtype_fnn(fnn_2), ?()), `%->%`([$valtype_fnn(fnn_2)], [$valtype_fnn(fnn_1)]))
     -- if (fnn_1 =/= fnn_2)
 
@@ -32457,7 +32457,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if (n <= o0)
 
   ;; 6-typing.watsup:700.1-703.34
-  rule reinterpret {C : context, nt_1 : numtype, nt_2 : numtype, o0 : nat, o1 : nat}:
+  rule cvtop-reinterpret {C : context, nt_1 : numtype, nt_2 : numtype, o0 : nat, o1 : nat}:
     `%|-%:%`(C, CVTOP_instr(nt_1, REINTERPRET_cvtop, nt_2, ?()), `%->%`([$valtype_numtype(nt_2)], [$valtype_numtype(nt_1)]))
     -- if (nt_1 =/= nt_2)
     -- where ?(o1) = $size($valtype_numtype(nt_2))
@@ -32465,7 +32465,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if ($size($valtype_numtype(nt_1)) = ?(o0))
 
   ;; 6-typing.watsup:705.1-708.50
-  rule convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?, o0 : nat, o1 : nat}:
+  rule cvtop-convert-i {C : context, inn_1 : inn, inn_2 : inn, sx? : sx?, o0 : nat, o1 : nat}:
     `%|-%:%`(C, CVTOP_instr($numtype_inn(inn_1), CONVERT_cvtop, $numtype_inn(inn_2), sx?{sx}), `%->%`([$valtype_inn(inn_2)], [$valtype_inn(inn_1)]))
     -- if (inn_1 =/= inn_2)
     -- where ?(o0) = $size($valtype_inn(inn_1))
@@ -32473,7 +32473,7 @@ relation Instr_ok: `%|-%:%`(context, instr, functype)
     -- if ((sx?{sx} = ?()) <=> (o0 > o1))
 
   ;; 6-typing.watsup:710.1-712.24
-  rule convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
+  rule cvtop-convert-f {C : context, fnn_1 : fnn, fnn_2 : fnn}:
     `%|-%:%`(C, CVTOP_instr($numtype_fnn(fnn_1), CONVERT_cvtop, $numtype_fnn(fnn_2), ?()), `%->%`([$valtype_fnn(fnn_2)], [$valtype_fnn(fnn_1)]))
     -- if (fnn_1 =/= fnn_2)
 

--- a/spectec/test-prose/TEST.md
+++ b/spectec/test-prose/TEST.md
@@ -93,15 +93,10 @@ validation_of_TESTOP t testop
 validation_of_RELOP t relop
 - The instruction is valid with type ([t, t] -> [I32]).
 
-validation_of_CVTOP t_1 REINTERPRET t_2 ?()
-- t_1 must be different with t_2.
-- $size(t_1) must be equal to $size(t_2).
-- The instruction is valid with type ([t_2] -> [t_1]).
-
-validation_of_CVTOP inn_1 CONVERT inn_2 sx?
-- inn_1 must be different with inn_2.
-- (($size(inn_1) > $size(inn_2))) and ((sx? is ?())) are equivalent.
-- The instruction is valid with type ([inn_2] -> [inn_1]).
+validation_of_CVTOP nt_1 REINTERPRET nt_2 ?()
+- nt_1 must be different with nt_2.
+- $size(nt_1) must be equal to $size(nt_2).
+- The instruction is valid with type ([nt_2] -> [nt_1]).
 
 validation_of_LOCAL.GET x
 - |C.LOCAL| must be greater than x.
@@ -1010,11 +1005,6 @@ validation_of_CVTOP nt_1 REINTERPRET nt_2 ?()
 - nt_1 must be different with nt_2.
 - $size(nt_1) must be equal to $size(nt_2).
 - The instruction is valid with type ([nt_2] -> [nt_1]).
-
-validation_of_CVTOP inn_1 CONVERT inn_2 sx?
-- inn_1 must be different with inn_2.
-- (($size(inn_1) > $size(inn_2))) and ((sx? is ?())) are equivalent.
-- The instruction is valid with type ([inn_2] -> [inn_1]).
 
 validation_of_REF.NULL rt
 - The instruction is valid with type ([] -> [rt]).
@@ -2818,11 +2808,6 @@ validation_of_CVTOP nt_1 REINTERPRET nt_2 ?()
 - nt_1 must be different with nt_2.
 - $size(nt_1) must be equal to $size(nt_2).
 - The instruction is valid with type ([nt_2] -> [nt_1]).
-
-validation_of_CVTOP inn_1 CONVERT inn_2 sx?
-- inn_1 must be different with inn_2.
-- (($size(inn_1) > $size(inn_2))) and ((sx? is ?())) are equivalent.
-- The instruction is valid with type ([inn_2] -> [inn_1]).
 
 validation_of_REF.NULL ht
 - Under the context C, ht must be valid.

--- a/spectec/test-prose/TEST.md
+++ b/spectec/test-prose/TEST.md
@@ -4597,9 +4597,6 @@ execution_of_CALL x
 2. Push (REF.FUNC_ADDR $funcaddr()[x]) to the stack.
 3. Execute (CALL_REF ?()).
 
-execution_of_CALL_REF
-1. YetI: TODO: It is likely that the value stack of two rules are different.
-
 execution_of_RETURN_CALL x
 1. Assert: Due to validation, (x < |$funcaddr()|).
 2. Push (REF.FUNC_ADDR $funcaddr()[x]) to the stack.
@@ -4707,21 +4704,6 @@ execution_of_ARRAY.NEW_ELEM x y
 6. Let ref^n be $elem(y).ELEM[i : n].
 7. Push ref^n to the stack.
 8. Execute (ARRAY.NEW_FIXED x n).
-
-execution_of_ARRAY.NEW_DATA x y
-1. Assert: Due to validation, a value of value type I32 is on the top of the stack.
-2. Pop (I32.CONST n) from the stack.
-3. Assert: Due to validation, a value of value type I32 is on the top of the stack.
-4. Pop (I32.CONST i) from the stack.
-5. Assert: Due to validation, $expanddt($type(x)) is of the case ARRAY.
-6. Let (ARRAY y_0) be $expanddt($type(x)).
-7. Let (mut, zt) be y_0.
-8. If ((i + ((n · $storagesize(zt)) / 8)) > |$data(y).DATA|), then:
-  a. Trap.
-9. Let $ztbytes(zt, c)^n be $inverse_of_concat_bytes($data(y).DATA[i : ((n · $storagesize(zt)) / 8)]).
-10. Let nt be $unpacknumtype(zt).
-11. Push (nt.CONST c)^n to the stack.
-12. Execute (ARRAY.NEW_FIXED x n).
 
 execution_of_ARRAY.GET sx? x
 1. Assert: Due to validation, a value of value type I32 is on the top of the stack.

--- a/spectec/test-prose/doc/exec/instructions-in.rst
+++ b/spectec/test-prose/doc/exec/instructions-in.rst
@@ -801,8 +801,7 @@ $${rule-prose: exec/call}
 
 $${rule: Step_read/call}
 
-CALL_REF
-^^^^^^^^
+.. _exec-call_ref:
 
 $${rule-prose: exec/call_ref}
 

--- a/spectec/test-prose/doc/valid/instructions-in.rst
+++ b/spectec/test-prose/doc/valid/instructions-in.rst
@@ -65,10 +65,7 @@ $${rule-prose: valid/cvtop}
 
 \
 
-$${rule+: 
-  Instr_ok/reinterpret
-  Instr_ok/convert-*
-}
+$${rule+: Instr_ok/cvtop-*}
 
 Reference Instructions
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/spectec/test-splice/TEST.md
+++ b/spectec/test-splice/TEST.md
@@ -1211,7 +1211,6 @@ warning: rule prose `exec/array.copy` was never spliced
 warning: rule prose `exec/array.fill` was never spliced
 warning: rule prose `exec/array.len` was never spliced
 warning: rule prose `exec/array.get` was never spliced
-warning: rule prose `exec/array.new_data` was never spliced
 warning: rule prose `exec/array.new_elem` was never spliced
 warning: rule prose `exec/array.new_default` was never spliced
 warning: rule prose `exec/array.new` was never spliced
@@ -1222,7 +1221,6 @@ warning: rule prose `exec/ref.test` was never spliced
 warning: rule prose `exec/ref.func` was never spliced
 warning: rule prose `exec/return_call_ref` was never spliced
 warning: rule prose `exec/return_call` was never spliced
-warning: rule prose `exec/call_ref` was never spliced
 warning: rule prose `exec/call` was never spliced
 warning: rule prose `exec/br_on_cast_fail` was never spliced
 warning: rule prose `exec/br_on_cast` was never spliced

--- a/spectec/test-splice/TEST.md
+++ b/spectec/test-splice/TEST.md
@@ -692,7 +692,6 @@ warning: rule `Instr_ok/binop` was never spliced
 warning: rule `Instr_ok/testop` was never spliced
 warning: rule `Instr_ok/relop` was never spliced
 warning: rule `Instr_ok/extend` was never spliced
-warning: rule `Instr_ok/reinterpret` was never spliced
 warning: rule `Instr_ok/ref.null` was never spliced
 warning: rule `Instr_ok/ref.func` was never spliced
 warning: rule `Instr_ok/ref.i31` was never spliced
@@ -1346,7 +1345,6 @@ warning: rule prose `valid/ref.is_null` was never spliced
 warning: rule prose `valid/ref.i31` was never spliced
 warning: rule prose `valid/ref.func` was never spliced
 warning: rule prose `valid/ref.null` was never spliced
-warning: rule prose `valid/cvtop` was never spliced
 warning: rule prose `valid/cvtop` was never spliced
 warning: rule prose `valid/extend` was never spliced
 warning: rule prose `valid/relop` was never spliced

--- a/spectec/test-splice/spec-latex.in.tex
+++ b/spectec/test-splice/spec-latex.in.tex
@@ -56,7 +56,7 @@ An instruction sequence #{:instr*} is well-typed with an instruction type #{func
 ##{rule+: Instr_ok/if}
 
 
-##{rule-ignore: Instr_ok/convert-*}
+##{rule-ignore: Instr_ok/cvtop-*}
 
 
 \subsection*{Runtime}

--- a/spectec/test-splice/spec-sphinx.in.rst
+++ b/spectec/test-splice/spec-sphinx.in.rst
@@ -40,7 +40,7 @@ $${rule+: Instr_ok/loop}
 $${rule+: Instr_ok/if}
 
 
-$${rule-ignore: Instr_ok/convert-*}
+$${rule-ignore: Instr_ok/cvtop-*}
 
 
 **Runtime**


### PR DESCRIPTION
As mentioned in #63, there were duplicate prose for:

```
warning: prose rule `exec/array.new_data` has multiple definitions
warning: prose rule `exec/call_ref` has multiple definitions
warning: prose rule `valid/cvtop` has multiple definitions
```

There were two reasons:

**(1) Manually-written algorithms**

Execution algorithms for `exec/array.new_data` and `exec/call_ref` are written manually in `backend-interpreter/manual.ml`, for translating them to AL were quite tricky. The problem was that the failed translation (indicated by `YetI`) from `il2al/translate.ml` and the manual algorithms were counted twice. Thus, I've modified `exe-watsup/main.ml` to nullify the failed translations for manual algorithms.

This resolves the upper-two warnings.

**(2) Prefix validation rule names**

When translating formal rules to prose, we first group validation rules by their name's prefix. For example, `Instr_ok/select-expl` and `Instr_ok/select-impl` are grouped by their prefix `select-`. The rule names for the validation of `cvtop` were not properly named with the same prefix, so I re-named them to: `cvtop-reinterpret`, `cvtop-convert-i`, and `cvtop-convert-f`.

This handles the last warning, so all warnings are now gone. **Yet**, the current validation prose generator *cannot* handle multiple validation rules per Wasm instruction. `select` and `cvtop` are such cases, where the generator only takes the first rule and translates it, ignoring the rest.

https://github.com/Wasm-DSL/spectec/blob/9a1f5646259961c9c3c52cae1dd1dc79b73e8052/spectec/src/backend-prose/gen.ml#L83 

This should be addressed, but will take some time since this requires some discussion with @f52985.