### PR TITLE
Unbounded nats

### DIFF
--- a/.github/workflows/ci-spectec.yml
+++ b/.github/workflows/ci-spectec.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           ocaml-compiler: 4.14.x
       - name: Setup Dune
-        run: opam install --yes dune menhir mdx
+        run: opam install --yes dune menhir mdx zarith
       - name: Setup Latex
         run: sudo apt-get update -y && sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
       - name: Setup Sphinx

--- a/spectec/README.md
+++ b/spectec/README.md
@@ -135,7 +135,7 @@ Lowering from EL into IL infers additional information and makes it explicit in 
 
 ### Prerequisites
 
-You will need `ocaml` installed with `dune`, `menhir`, and `mdx` using `opam`.
+You will need `ocaml` installed with `dune`, `menhir`, `mdx`, and the `zarith` library using `opam`.
 
 * Install `opam` version 2.0.5 or higher.
   ```
@@ -146,12 +146,11 @@ You will need `ocaml` installed with `dune`, `menhir`, and `mdx` using `opam`.
 * Set `ocaml` as version 5.0.0 or higher.
   ```
   $ opam switch create 5.0.0
-  $ opam install dune menhir mdx
   ```
   
-* Install `dune` version 3.11.0, `menhir` version 20230608, and `mdx` version 2.3.1 via `opam` (default versions)
+* Install `dune` version 3.11.0, `menhir` version 20230608, `mdx` version 2.3.1, and `zarith` version 1.12, via `opam` (default versions)
   ```
-  $ opam install dune menhir mdx
+  $ opam install dune menhir mdx zarith
   ```
 
 ### Building the Project

--- a/spectec/src/al/al_util.ml
+++ b/spectec/src/al/al_util.ml
@@ -80,7 +80,7 @@ let sliceP ?(at = no) (e1, e2) = SliceP (e1, e2) |> mk_path at
 let dotP ?(at = no) kwd = DotP kwd |> mk_path at
 
 let numV i = NumV i
-let numV_of_int i = Int64.of_int i |> numV
+let numV_of_int i = Z.of_int i |> numV
 let boolV b = BoolV b
 let vecV vec = VecV vec
 let strV r = StrV r
@@ -90,8 +90,8 @@ let tupV vl = TupV vl
 let nullary s = CaseV (String.uppercase_ascii s, [])
 let listV a = ListV (ref a)
 let listV_of_list l = Array.of_list l |> listV
-let zero = numV 0L
-let one = numV 1L
+let zero = numV Z.zero
+let one = numV Z.one
 let empty_list = listV [||]
 let singleton v = listV [|v|]
 
@@ -167,10 +167,10 @@ let get_body = function
 let unwrap_textv: value -> string = function
   | TextV str -> str
   | v -> fail "text" v
-let unwrap_numv: value -> int64 = function
-  | NumV i64 -> i64
+let unwrap_numv: value -> Z.t = function
+  | NumV i -> i
   | v -> fail "int64" v
-let unwrap_numv_to_int (v: value): int = unwrap_numv v |> Int64.to_int
+let unwrap_numv_to_int (v: value): int = unwrap_numv v |> Z.to_int
 let unwrap_boolv: value -> bool = function
   | BoolV b -> b
   | v -> fail "boolean" v

--- a/spectec/src/al/ast.ml
+++ b/spectec/src/al/ast.ml
@@ -22,7 +22,7 @@ type ('a, 'b) record = ('a * 'b ref) list
 and store = (kwd', value) record
 
 and value =
-  | NumV of int64                      (* number *)
+  | NumV of Z.t                        (* number *)
   | BoolV of bool                      (* boolean *)
   | VecV of vec128                     (* vector *)
   | TextV of string                    (* string *)
@@ -76,7 +76,7 @@ type iter =
 and expr = expr' phrase
 and expr' =
   | VarE of id                          (* varid *)
-  | NumE of int64                       (* number *)
+  | NumE of Z.t                         (* number *)
   | BoolE of bool                       (* boolean *)
   | UnE of unop * expr                  (* unop expr *)
   | BinE of binop * expr * expr         (* expr binop expr *)

--- a/spectec/src/al/dune
+++ b/spectec/src/al/dune
@@ -1,5 +1,5 @@
 (library
   (name al)
-  (libraries util)
+  (libraries util zarith)
   (modules ast al_util print walk free eq)
 )

--- a/spectec/src/al/print.ml
+++ b/spectec/src/al/print.ml
@@ -54,7 +54,7 @@ and string_of_value = function
   | FrameV _ -> "FrameV"
   | StoreV _ -> "StoreV"
   | ListV lv -> "[" ^ string_of_values ", " (Array.to_list !lv) ^ "]"
-  | NumV n -> Printf.sprintf "0x%LX" n
+  | NumV n -> "0x" ^ Z.format "%X" n
   | BoolV b -> string_of_bool b
   | VecV v -> "VecV (" ^ String.concat " " (List.init 4 (fun i -> Int32.to_string (Bytes.get_int32_le (Bytes.of_string v) (i*4)))) ^ ")"
   | TextV s -> s
@@ -116,7 +116,7 @@ and string_of_record_expr r =
 
 and string_of_expr expr =
   match expr.it with
-  | NumE i -> Int64.to_string i
+  | NumE i -> Z.to_string i
   | BoolE b -> string_of_bool b
   | UnE (NotOp, { it = IsCaseOfE (e, kwd); _ }) ->
     sprintf "%s is not of the case %s" (string_of_expr e) (string_of_kwd kwd)
@@ -346,7 +346,7 @@ let rec structured_string_of_value = function
   | StoreV _ -> "StoreV"
   | ListV _ -> "ListV"
   | BoolV b -> "BoolV (" ^ string_of_bool b ^ ")"
-  | NumV n -> "NumV (" ^ Int64.to_string n ^ ")"
+  | NumV n -> "NumV (" ^ Z.to_string n ^ ")"
   | VecV v -> "VecV (" ^ String.concat " " (List.init 4 (fun i -> Int32.to_string (Bytes.get_int32_le (Bytes.of_string v) (i*4)))) ^ ")"
   | TextV s -> "TextV (" ^ s ^ ")"
   | TupV vl ->  "TupV (" ^ structured_string_of_values vl ^ ")"
@@ -378,7 +378,7 @@ and structured_string_of_record_expr r =
 
 and structured_string_of_expr expr =
   match expr.it with
-  | NumE i -> Int64.to_string i
+  | NumE i -> Z.to_string i
   | BoolE b -> string_of_bool b
   | UnE (op, e) ->
     "UnE ("

--- a/spectec/src/backend-interpreter/builtin.ml
+++ b/spectec/src/backend-interpreter/builtin.ml
@@ -25,7 +25,7 @@ let builtin () =
       CaseV ("DEF", [
         CaseV ("REC", [
           [| CaseV ("SUBD", [none "FINAL"; listV [||]; ftype]) |] |> listV
-        ]); numV 0L
+        ]); numV Z.zero
       ]) in
     name, StrV [
       "TYPE", ref (if !Construct.version = 3 then dt else arrow);
@@ -70,14 +70,14 @@ let builtin () =
   let tables = [
     "table",
     listV nulls
-    |> create_tableinst (TupV [ TupV [ numV 10L; numV 20L ]; nullary "FUNCREF" ]);
+    |> create_tableinst (TupV [ TupV [ numV (Z.of_int 10); numV (Z.of_int 20) ]; nullary "FUNCREF" ]);
   ] in
   (* Builtin memories *)
-  let zeros = numV 0L |> Array.make 0x10000 in
+  let zeros = numV Z.zero |> Array.make 0x10000 in
   let memories = [
     "memory",
     listV zeros
-    |> create_meminst (CaseV ("I8", [ TupV [ numV 1L; numV 2L ] ]));
+    |> create_meminst (CaseV ("I8", [ TupV [ numV Z.one; numV (Z.of_int 2) ] ]));
   ] in
 
   let append kind (name, inst) extern =
@@ -86,7 +86,7 @@ let builtin () =
 
     let addr =
       match Record.find kind (get_store ()) with
-      | ListV a -> Array.length !a |> Int64.of_int
+      | ListV a -> Array.length !a |> Z.of_int
       | _ -> failwith "Unreachable"
     in
     let new_extern =

--- a/spectec/src/backend-interpreter/manual.ml
+++ b/spectec/src/backend-interpreter/manual.ml
@@ -112,7 +112,7 @@ let group_bytes_by =
   let n' = varE "n'" in
 
   let bytes_ = iterE (varE "byte", ["byte"], List) in
-  let bytes_left = listE [accE (bytes_, sliceP (numE 0L, n))] in
+  let bytes_left = listE [accE (bytes_, sliceP (numE Z.zero, n))] in
   let bytes_right = callE
     (
       "group_bytes_by",
@@ -161,7 +161,7 @@ let array_new_data =
   let unpacknumtype = callE ("unpacknumtype", [zt]) in
   (* include z or not ??? *)
   let data = callE ("data", [y]) in
-  let group_bytes_by = callE ("group_bytes_by", [binE (DivOp, storagesize, numE 8L); bstar]) in
+  let group_bytes_by = callE ("group_bytes_by", [binE (DivOp, storagesize, numE (Z.of_int 8)); bstar]) in
   let inverse_of_bytes_ = iterE (callE ("inverse_of_ibytes", [storagesize; gb]), ["gb"], List) in
 
   RuleA (
@@ -180,7 +180,7 @@ let array_new_data =
           ifI (
             binE (
               GtOp,
-              binE (AddOp, i, binE (DivOp, binE (MulOp, n, storagesize), numE 8L)),
+              binE (AddOp, i, binE (DivOp, binE (MulOp, n, storagesize), numE (Z.of_int 8))),
               lenE (accE (callE ("data", [y]), dotP ("DATA", "datainst")))
             ),
             [ trapI () ],
@@ -191,7 +191,7 @@ let array_new_data =
             bstar,
             accE (
               accE (data, dotP ("DATA", "datainst")),
-              sliceP (i, binE (DivOp, binE (MulOp, n, storagesize), numE 8L))
+              sliceP (i, binE (DivOp, binE (MulOp, n, storagesize), numE (Z.of_int 8)))
             )
           );
           letI (gbstar, group_bytes_by);
@@ -210,7 +210,7 @@ let return_instrs_of_instantiate config =
   let store, frame, rhs = config in
   [
     enterI (
-      frameE (Some (numE 0L), frame),
+      frameE (Some (numE Z.zero), frame),
       listE ([ caseE (("FRAME_", "admininstr"), []) ]), rhs
     );
     returnI (Some (tupE [ store; varE "mm" ]))

--- a/spectec/src/backend-latex/render.ml
+++ b/spectec/src/backend-latex/render.ml
@@ -562,19 +562,19 @@ and render_exp env e =
   | VarE (id, args) ->
     render_apply render_varid render_exp env env.show_syn id args
   | BoolE b -> render_atom env (Atom (string_of_bool b) $$ e.at % ref "bool")
-  | NatE (DecOp, n) -> string_of_int n
+  | NatE (DecOp, n) -> Z.to_string n
   | NatE (HexOp, n) ->
-    let fmt : (_, _, _) format =
-      if n < 0x100 then "%02X" else
-      if n < 0x10000 then "%04X" else
+    let fmt =
+      if n < Z.of_int 0x100 then "%02X" else
+      if n < Z.of_int 0x10000 then "%04X" else
       "%X"
-    in "\\mathtt{0x" ^ Printf.sprintf fmt n ^ "}"
+    in "\\mathtt{0x" ^ Z.format fmt n ^ "}"
   | NatE (CharOp, n) ->
-    let fmt : (_, _, _) format =
-      if n < 0x100 then "%02X" else
-      if n < 0x10000 then "%04X" else
+    let fmt =
+      if n < Z.of_int 0x100 then "%02X" else
+      if n < Z.of_int 0x10000 then "%04X" else
       "%X"
-    in "\\mathrm{U{+}" ^ Printf.sprintf fmt n ^ "}"
+    in "\\mathrm{U{+}" ^ Z.format fmt n ^ "}"
   | TextE t -> "``" ^ t ^ "''"
   | UnE (op, e2) -> "{" ^ render_unop op ^ render_exp env e2 ^ "}"
   | BinE (e1, ExpOp, ({it = ParenE (e2, _); _ } | e2)) ->
@@ -712,19 +712,19 @@ and render_sym env g =
   match g.it with
   | VarG (id, args) ->
     render_apply render_gramid render_exp_as_sym env env.show_gram id args
-  | NatG (DecOp, n) -> string_of_int n
+  | NatG (DecOp, n) -> Z.to_string n
   | NatG (HexOp, n) ->
-    let fmt : (_, _, _) format =
-      if n < 0x100 then "%02X" else
-      if n < 0x10000 then "%04X" else
+    let fmt =
+      if n < Z.of_int 0x100 then "%02X" else
+      if n < Z.of_int 0x10000 then "%04X" else
       "%X"
-    in "\\mathtt{0x" ^ Printf.sprintf fmt n ^ "}"
+    in "\\mathtt{0x" ^ Z.format fmt n ^ "}"
   | NatG (CharOp, n) ->
-    let fmt : (_, _, _) format =
-      if n < 0x100 then "%02X" else
-      if n < 0x10000 then "%04X" else
+    let fmt =
+      if n < Z.of_int 0x100 then "%02X" else
+      if n < Z.of_int 0x10000 then "%04X" else
       "%X"
-    in "\\mathrm{U{+}" ^ Printf.sprintf fmt n ^ "}"
+    in "\\mathrm{U{+}" ^ Z.format fmt n ^ "}"
   | TextG t -> "`" ^ t ^ "'"
   | EpsG -> "\\epsilon"
   | SeqG gs -> render_syms "~" env gs

--- a/spectec/src/backend-prose/render.ml
+++ b/spectec/src/backend-prose/render.ml
@@ -91,9 +91,8 @@ and al_to_el_path pl =
 and al_to_el_expr expr =
   let exp' =
     match expr.it with
-    | Al.Ast.NumE i -> 
-        let ei = Int64.to_int i in
-        let eli = El.Ast.NatE (El.Ast.DecOp, ei) in
+    | Al.Ast.NumE i ->
+        let eli = El.Ast.NatE (El.Ast.DecOp, i) in
         Some eli
     | Al.Ast.UnE (op, e) ->
         let* elop = al_to_el_unop op in 

--- a/spectec/src/el/ast.ml
+++ b/spectec/src/el/ast.ml
@@ -12,7 +12,7 @@ type 'a nl_list = 'a nl_elem list
 
 (* Terminals *)
 
-type nat = int
+type nat = Z.t
 type text = string
 type id = string phrase
 
@@ -172,7 +172,7 @@ and path' =
 and sym = sym' phrase
 and sym' =
   | VarG of id * arg list                    (* gramid (`(` arg,* `)`)? *)
-  | NatG of natop * int                      (* nat *)
+  | NatG of natop * nat                      (* nat *)
   | TextG of string                          (* `"`text`"` *)
   | EpsG                                     (* `eps` *)
   | SeqG of sym nl_list                      (* sym sym *)

--- a/spectec/src/el/dune
+++ b/spectec/src/el/dune
@@ -1,5 +1,5 @@
 (library
   (name el)
-  (libraries util)
+  (libraries util zarith)
   (modules ast eq free subst convert print iter)
 )

--- a/spectec/src/el/print.ml
+++ b/spectec/src/el/print.ml
@@ -147,9 +147,9 @@ and string_of_exp e =
   | VarE (id, args) -> id.it ^ string_of_args args
   | AtomE atom -> string_of_atom atom
   | BoolE b -> string_of_bool b
-  | NatE (DecOp, n) -> string_of_int n
-  | NatE (HexOp, n) -> Printf.sprintf "0x%X" n
-  | NatE (CharOp, n) -> Printf.sprintf "U+%X" n
+  | NatE (DecOp, n) -> Z.to_string n
+  | NatE (HexOp, n) -> "0x" ^ Z.format "%X" n
+  | NatE (CharOp, n) -> "U+" ^ Z.format "%X" n
   | TextE t -> "\"" ^ String.escaped t ^ "\""
   | UnE (op, e2) -> string_of_unop op ^ " " ^ string_of_exp e2
   | BinE (e1, op, e2) ->
@@ -225,9 +225,9 @@ and string_of_prem prem =
 and string_of_sym g =
   match g.it with
   | VarG (id, args) -> id.it ^ string_of_args args
-  | NatG (DecOp, n) -> string_of_int n
-  | NatG (HexOp, n) -> Printf.sprintf "0x%X" n
-  | NatG (CharOp, n) -> Printf.sprintf "U+%X" n
+  | NatG (DecOp, n) -> Z.to_string n
+  | NatG (HexOp, n) -> "0x" ^ Z.format "%X" n
+  | NatG (CharOp, n) -> "U+" ^ Z.format "%X" n
   | TextG t -> "\"" ^ String.escaped t ^ "\""
   | EpsG -> "eps"
   | SeqG gs -> "{" ^ concat " " (map_filter_nl_list string_of_sym gs) ^ "}"

--- a/spectec/src/frontend/elab.ml
+++ b/spectec/src/frontend/elab.ml
@@ -721,7 +721,7 @@ and infer_exp' env e : Il.exp' * typ =
     Il.LenE e1', NumT NatT $ e.at
   | SizeE id ->
     let _ = find "grammar" env.syms id in
-    NatE 0, NumT NatT $ e.at
+    NatE Z.zero, NumT NatT $ e.at
   | ParenE (e1, _) ->
     infer_exp' env e1
   | TupE es ->

--- a/spectec/src/frontend/lexer.mll
+++ b/spectec/src/frontend/lexer.mll
@@ -19,17 +19,10 @@ let error_nest start lexbuf msg =
   lexbuf.Lexing.lex_start_p <- start;
   error lexbuf msg
 
-let nat lexbuf s =
-  try
-    let n = int_of_string s in
-    if n >= 0 then n else raise (Failure "")
-  with Failure _ -> error lexbuf "nat literal out of range"
-
-let hex lexbuf s =
-  try
-    let n = int_of_string s in
-    if n >= 0 then n else raise (Failure "")
-  with Failure _ -> error lexbuf "hex literal out of range"
+let nat _lexbuf s = Z.of_string s
+let hex _lexbuf s = Z.of_string s
+let int lexbuf s =
+  try int_of_string s with Failure _ -> error lexbuf "hex literal out of range"
 
 let text _lexbuf s =
   let b = Buffer.create (String.length s) in
@@ -204,10 +197,10 @@ and token = parse
   | "_|_" { BOT }
   | "^|^" { TOP }
   | "%" { HOLE }
-  | "%"(nat as s) { HOLEN (nat lexbuf s) }
+  | "%"(nat as s) { HOLEN (int lexbuf s) }
   | "%%" { MULTIHOLE }
   | "!%" { SKIP }
-  | "!%"(nat as s) { SKIPN (nat lexbuf s) }
+  | "!%"(nat as s) { SKIPN (int lexbuf s) }
   | "!%%" { MULTISKIP }
   | "#" { FUSE }
 

--- a/spectec/src/frontend/parser.mly
+++ b/spectec/src/frontend/parser.mly
@@ -100,7 +100,7 @@ let is_post_exp e =
 %token IF OTHERWISE HINT_LPAREN
 %token EPS INFINITY
 %token<bool> BOOLLIT
-%token<int> NATLIT HEXLIT CHARLIT
+%token<Z.t> NATLIT HEXLIT CHARLIT
 %token<string> TEXTLIT
 %token<string> UPID LOID DOTID UPID_LPAREN LOID_LPAREN
 %token EOF
@@ -202,7 +202,7 @@ gramid_lparen : id_lparen { $1 $ at $sloc }
 ruleid : ruleid_ { $1 }
 ruleid_ :
   | id { $1 }
-  | NATLIT { Int.to_string $1 }
+  | NATLIT { Z.to_string $1 }
   | BOOLLIT { Bool.to_string $1 }
   | IF { "if" }
   | VAR { "var" }

--- a/spectec/src/il/ast.ml
+++ b/spectec/src/il/ast.ml
@@ -6,7 +6,7 @@ open Util.Source
 
 (* Terminals *)
 
-type nat = int
+type nat = Z.t
 type text = string
 type id = string phrase
 

--- a/spectec/src/il/dune
+++ b/spectec/src/il/dune
@@ -1,5 +1,5 @@
 (library
   (name il)
-  (libraries util)
+  (libraries util zarith)
   (modules ast eq free print validation)
 )

--- a/spectec/src/il/print.ml
+++ b/spectec/src/il/print.ml
@@ -148,7 +148,7 @@ and string_of_exp e =
   match e.it with
   | VarE id -> id.it
   | BoolE b -> string_of_bool b
-  | NatE n -> string_of_int n
+  | NatE n -> Z.to_string n
   | TextE t -> "\"" ^ String.escaped t ^ "\""
   | UnE (op, e2) -> string_of_unop op ^ " " ^ string_of_exp e2
   | BinE (op, e1, e2) ->

--- a/spectec/src/il2al/translate.ml
+++ b/spectec/src/il2al/translate.ml
@@ -114,7 +114,7 @@ let rec translate_iter = function
 and translate_expr exp =
   let at = exp.at in
   match exp.it with
-  | Il.NatE n -> numE (Int64.of_int n) ~at:at
+  | Il.NatE n -> numE n ~at:at
   | Il.BoolE b -> boolE b ~at:at
   (* List *)
   | Il.LenE inner_exp -> lenE (translate_expr inner_exp) ~at:at
@@ -507,7 +507,7 @@ let rec translate_letpr lhs rhs targets cont =
     else
     [
       ifI
-        ( binE (EqOp, lenE rhs, numE (Int64.of_int (List.length es))),
+        ( binE (EqOp, lenE rhs, numE (Z.of_int (List.length es))),
           letI (listE es' ~at:lhs_at, rhs) ~at:at :: translate_bindings bindings,
           [] );
     ]
@@ -546,7 +546,7 @@ let rec translate_letpr lhs rhs targets cont =
       match e.it with
       | ListE es ->
         let bindings', es' = extract_non_names es in
-        Some (numE (Int64.of_int (List.length es))), bindings', listE es'
+        Some (numE (Z.of_int (List.length es))), bindings', listE es'
       | IterE (({ it = VarE _; _ } | { it = SubE _; _ }), _, ListN (e', None)) ->
         Some e', [], e
       | _ ->

--- a/spectec/src/il2al/transpile.ml
+++ b/spectec/src/il2al/transpile.ml
@@ -38,13 +38,13 @@ let both_empty cond1 cond2 =
   let get_list cond =
     match cond.it with
     | BinE (EqOp, e, { it = ListE []; _ })
-    | BinE (EqOp, { it = ListE []; _ }, e)
-    | BinE (EqOp, { it = LenE e; _ }, { it = NumE 0L; _ })
-    | BinE (EqOp, { it = NumE 0L; _ }, { it = LenE e; _ })
-    | BinE (LtOp, { it = LenE e; _ }, { it = NumE 1L; _ })
-    | BinE (LeOp, { it = LenE e; _ }, { it = NumE 0L; _ })
-    | BinE (GeOp, { it = NumE 0L; _ }, { it = LenE e; _ })
-    | BinE (GeOp, { it = NumE 1L; _ }, { it = LenE e; _ }) -> Some e
+    | BinE (EqOp, { it = ListE []; _ }, e) -> Some e
+    | BinE (EqOp, { it = LenE e; _ }, { it = NumE z; _ })
+    | BinE (EqOp, { it = NumE z; _ }, { it = LenE e; _ })
+    | BinE (LeOp, { it = LenE e; _ }, { it = NumE z; _ })
+    | BinE (GeOp, { it = NumE z; _ }, { it = LenE e; _ }) when z = Z.zero -> Some e
+    | BinE (LtOp, { it = LenE e; _ }, { it = NumE z; _ })
+    | BinE (GeOp, { it = NumE z; _ }, { it = LenE e; _ }) when z = Z.one -> Some e
     | _ -> None
   in
   match get_list cond1, get_list cond2 with
@@ -55,13 +55,13 @@ let both_non_empty cond1 cond2 =
   let get_list cond =
     match cond.it with
     | BinE (NeOp, e, { it = ListE []; _ })
-    | BinE (NeOp, { it = ListE []; _ }, e)
-    | BinE (NeOp, { it = LenE e; _ }, { it = NumE 0L; _ })
-    | BinE (NeOp, { it = NumE 0L; _ }, { it = LenE e; _ })
-    | BinE (LtOp, { it = NumE 0L; _ }, { it = LenE e; _ })
-    | BinE (GtOp, { it = LenE e; _ }, { it = NumE 0L; _ })
-    | BinE (LeOp, { it = NumE 1L; _ }, { it = LenE e; _ })
-    | BinE (GeOp, { it = LenE e; _ }, { it = NumE 1L; _ }) -> Some e
+    | BinE (NeOp, { it = ListE []; _ }, e) -> Some e
+    | BinE (NeOp, { it = LenE e; _ }, { it = NumE z; _ })
+    | BinE (NeOp, { it = NumE z; _ }, { it = LenE e; _ })
+    | BinE (LtOp, { it = NumE z; _ }, { it = LenE e; _ })
+    | BinE (GtOp, { it = LenE e; _ }, { it = NumE z; _ }) when z = Z.zero -> Some e
+    | BinE (LeOp, { it = NumE z; _ }, { it = LenE e; _ })
+    | BinE (GeOp, { it = LenE e; _ }, { it = NumE z; _ }) when z = Z.one-> Some e
     | _ -> None
   in
   match get_list cond1, get_list cond2 with


### PR DESCRIPTION
Use the Zarith library to represent nats as bigints in EL, IL, and AL. This way the DSL can e.g. represent i128 properly.

This is mostly a mechanical change. The main annoyance is that, as a library type, Z.t does not have literals, which is particularly annoying for pattern matching, where we need to move the comparison to guard conditions.

@jaehyun1ee, PTAL.