### PR TITLE
Annotate IL atoms with type ids, too

### DIFF
--- a/spectec/src/backend-prose/gen.ml
+++ b/spectec/src/backend-prose/gen.ml
@@ -84,7 +84,7 @@ let vrule_group_to_prose ((_name, vrules): vrule_group) =
 
   (* name *)
   let winstr_name = match winstr.it with
-  | Ast.CaseE (Ast.Atom winstr_name, _) -> winstr_name
+  | Ast.CaseE ({it = Ast.Atom winstr_name; _}, _) -> winstr_name
   | _ -> failwith "unreachable"
   in
   let name = kwd winstr_name winstr.note in

--- a/spectec/src/el/eq.ml
+++ b/spectec/src/el/eq.ml
@@ -18,13 +18,22 @@ let eq_nl_elem eq_x e1 e2 =
 let eq_nl_list eq_x xs1 xs2 = eq_list (eq_nl_elem eq_x) xs1 xs2
 
 
+(* Ids *)
+
+let eq_id i1 i2 =
+  i1.it = i2.it
+
+let eq_atom atom1 atom2 =
+  atom1.it = atom2.it
+
+
 (* Iteration *)
 
 let rec eq_iter iter1 iter2 =
   match iter1, iter2 with
   | ListN (e1, None), ListN (e2, None) -> eq_exp e1 e2
   | ListN (e1, Some id1), ListN (e2, Some id2) ->
-    eq_exp e1 e2 && id1.it = id2.it
+    eq_exp e1 e2 && eq_id id1 id2
   | _, _ -> iter1 = iter2
 
 
@@ -33,7 +42,7 @@ let rec eq_iter iter1 iter2 =
 and eq_typ t1 t2 =
   match t1.it, t2.it with
   | VarT (id1, args1), VarT (id2, args2) ->
-    id1.it = id2.it && eq_list eq_arg args1 args2
+    eq_id id1 id2 && eq_list eq_arg args1 args2
   | ParenT t11, ParenT t21 -> eq_typ t11 t21
   | TupT ts1, TupT ts2 -> eq_list eq_typ ts1 ts2
   | IterT (t11, iter1), IterT (t21, iter2) ->
@@ -44,19 +53,19 @@ and eq_typ t1 t2 =
     eq_nl_list eq_typcase tcs1 tcs2 && dots12 = dots22
   | ConT tc1, ConT tc2 -> eq_typcon tc1 tc2
   | RangeT tes1, RangeT tes2 -> eq_nl_list eq_typenum tes1 tes2
-  | AtomT atom1, AtomT atom2 -> atom1.it = atom2.it
+  | AtomT atom1, AtomT atom2 -> eq_atom atom1 atom2
   | SeqT ts1, SeqT ts2 -> eq_list eq_typ ts1 ts2
   | InfixT (t11, atom1, t12), InfixT (t21, atom2, t22) ->
-    eq_typ t11 t21 && atom1.it = atom2.it && eq_typ t12 t22
+    eq_typ t11 t21 && eq_atom atom1 atom2 && eq_typ t12 t22
   | BrackT (l1, t11, r1), BrackT (l2, t21, r2) ->
-    l1.it = l2.it && eq_typ t11 t21 && r1.it = r2.it
+    eq_atom l1 l2 && eq_typ t11 t21 && eq_atom r1 r2
   | _, _ -> t1.it = t2.it
 
 and eq_typfield (atom1, (t1, prems1), _) (atom2, (t2, prems2), _) =
-  atom1.it = atom2.it && eq_typ t1 t2 && eq_nl_list eq_prem prems1 prems2
+  eq_atom atom1 atom2 && eq_typ t1 t2 && eq_nl_list eq_prem prems1 prems2
 
 and eq_typcase (atom1, (t1, prems1), _) (atom2, (t2, prems2), _) =
-  atom1.it = atom2.it && eq_typ t1 t2 && eq_nl_list eq_prem prems1 prems2
+  eq_atom atom1 atom2 && eq_typ t1 t2 && eq_nl_list eq_prem prems1 prems2
 
 and eq_typenum (e1, eo1) (e2, eo2) =
   eq_exp e1 e2 && eq_opt eq_exp eo1 eo2
@@ -70,7 +79,7 @@ and eq_typcon ((t1, prems1), _) ((t2, prems2), _) =
 and eq_exp e1 e2 =
   match e1.it, e2.it with
   | VarE (id1, args1), VarE (id2, args2) ->
-    id1.it = id2.it && eq_list eq_arg args1 args2
+    eq_id id1 id2 && eq_list eq_arg args1 args2
   | UnE (op1, e11), UnE (op2, e21) -> op1 = op2 && eq_exp e11 e21
   | BinE (e11, op1, e12), BinE (e21, op2, e22) ->
     eq_exp e11 e21 && op1 = op2 && eq_exp e12 e22
@@ -90,14 +99,14 @@ and eq_exp e1 e2 =
   | SeqE es1, SeqE es2
   | TupE es1, TupE es2 -> eq_list eq_exp es1 es2
   | StrE efs1, StrE efs2 -> eq_nl_list eq_expfield efs1 efs2
-  | DotE (e11, atom1), DotE (e21, atom2) -> eq_exp e11 e21 && atom1.it = atom2.it
-  | AtomE atom1, AtomE atom2 -> atom1.it = atom2.it
+  | DotE (e11, atom1), DotE (e21, atom2) -> eq_exp e11 e21 && eq_atom atom1 atom2
+  | AtomE atom1, AtomE atom2 -> eq_atom atom1 atom2
   | InfixE (e11, atom1, e12), InfixE (e21, atom2, e22) ->
-    eq_exp e11 e21 && atom1.it = atom2.it && eq_exp e12 e22
+    eq_exp e11 e21 && eq_atom atom1 atom2 && eq_exp e12 e22
   | BrackE (l1, e1, r1), BrackE (l2, e2, r2) ->
-    l1.it = l2.it && eq_exp e1 e2 && r1.it = r2.it
+    eq_atom l1 l2 && eq_exp e1 e2 && eq_atom r1 r2
   | CallE (id1, args1), CallE (id2, args2) ->
-    id1.it = id2.it && eq_list eq_arg args1 args2
+    eq_id id1 id2 && eq_list eq_arg args1 args2
   | IterE (e11, iter1), IterE (e21, iter2) ->
     eq_exp e11 e21 && eq_iter iter1 iter2
   | TypE (e11, t1), TypE (e21, t2) ->
@@ -105,7 +114,7 @@ and eq_exp e1 e2 =
   | _, _ -> e1.it = e2.it
 
 and eq_expfield (atom1, e1) (atom2, e2) =
-  atom1.it = atom2.it && eq_exp e1 e2
+  eq_atom atom1 atom2 && eq_exp e1 e2
 
 and eq_path p1 p2 =
   match p1.it, p2.it with
@@ -113,7 +122,7 @@ and eq_path p1 p2 =
   | IdxP (p11, e1), IdxP (p21, e2) -> eq_path p11 p21 && eq_exp e1 e2
   | SliceP (p11, e11, e12), SliceP (p21, e21, e22) ->
     eq_path p11 p21 && eq_exp e11 e21 && eq_exp e12 e22
-  | DotP (p11, atom1), DotP (p21, atom2) -> eq_path p11 p21 && atom1.it = atom2.it
+  | DotP (p11, atom1), DotP (p21, atom2) -> eq_path p11 p21 && eq_atom atom1 atom2
   | _, _ -> p1.it = p2.it
 
 
@@ -121,8 +130,8 @@ and eq_path p1 p2 =
 
 and eq_prem prem1 prem2 =
   match prem1.it, prem2.it with
-  | VarPr (id1, t1), VarPr (id2, t2) -> id1.it = id2.it && eq_typ t1 t2
-  | RulePr (id1, e1), RulePr (id2, e2) -> id1.it = id2.it && eq_exp e1 e2
+  | VarPr (id1, t1), VarPr (id2, t2) -> eq_id id1 id2 && eq_typ t1 t2
+  | RulePr (id1, e1), RulePr (id2, e2) -> eq_id id1 id2 && eq_exp e1 e2
   | IfPr e1, IfPr e2 -> eq_exp e1 e2
   | IterPr (prem11, iter1), IterPr (prem21, iter2) ->
     eq_prem prem11 prem21 && eq_iter iter1 iter2
@@ -134,7 +143,7 @@ and eq_prem prem1 prem2 =
 and eq_sym g1 g2 =
   match g1.it, g2.it with
   | VarG (id1, args1), VarG (id2, args2) ->
-    id1.it = id2.it && eq_list eq_arg args1 args2
+    eq_id id1 id2 && eq_list eq_arg args1 args2
   | SeqG gs1, SeqG gs2
   | AltG gs1, AltG gs2 -> eq_nl_list eq_sym gs1 gs2
   | TupG gs1, TupG gs2 -> eq_list eq_sym gs1 gs2
@@ -158,7 +167,7 @@ and eq_arg a1 a2 =
 
 and eq_param p1 p2 =
   match p1.it, p2.it with
-  | ExpP (id1, t1), ExpP (id2, t2) -> id1.it = id2.it && eq_typ t1 t2
-  | TypP id1, TypP id2 -> id1.it = id2.it
-  | GramP (id1, t1), GramP (id2, t2) -> id1.it = id2.it && eq_typ t1 t2
+  | ExpP (id1, t1), ExpP (id2, t2) -> eq_id id1 id2 && eq_typ t1 t2
+  | TypP id1, TypP id2 -> eq_id id1 id2
+  | GramP (id1, t1), GramP (id2, t2) -> eq_id id1 id2 && eq_typ t1 t2
   | _, _ -> false

--- a/spectec/src/frontend/elab.ml
+++ b/spectec/src/frontend/elab.ml
@@ -442,7 +442,7 @@ let elab_hints tid = List.map (elab_hint tid)
 
 let elab_atom atom tid =
   atom.note := tid.it;
-  match atom.it with
+  (match atom.it with
   | Atom s -> Il.Atom s
   | Infinity -> Il.Infinity
   | Bot -> Il.Bot
@@ -483,6 +483,7 @@ let elab_atom atom tid =
   | RBrack -> Il.RBrack
   | LBrace -> Il.LBrace
   | RBrace -> Il.RBrace
+  ) $$ atom.at % !(atom.note)
 
 let numtyps = [NatT; IntT; RatT; RealT]
 
@@ -805,7 +806,9 @@ and elab_typ_notation env tid t : Il.mixop * Il.typ list * typ list =
       ts1', ts1
   | ParenT t1 ->
     let mixop1, ts1', ts1 = elab_typ_notation env tid t1 in
-    merge_mixop (merge_mixop [[Il.LParen]] mixop1) [[Il.RParen]], ts1', ts1
+    let l = Il.LParen $$ t.at % tid.it in
+    let r = Il.RParen $$ t.at % tid.it in
+    merge_mixop (merge_mixop [[l]] mixop1) [[r]], ts1', ts1
   | IterT (t1, iter) ->
     (match iter with
     | List1 | ListN _ -> error t.at "illegal iterator in notation type"
@@ -814,7 +817,7 @@ and elab_typ_notation env tid t : Il.mixop * Il.typ list * typ list =
       let iter' = elab_iter env iter in
       let tit = IterT (tup_typ ts1 t1.at, iter) $ t.at in
       let t' = Il.IterT (tup_typ' ts1' t1.at, iter') $ t.at in
-      let op = match iter with Opt -> Il.Quest | _ -> Il.Star in
+      let op = (match iter with Opt -> Il.Quest | _ -> Il.Star) $$ t.at % tid.it in
       (if mixop1 = [[]; []] then mixop1 else [List.flatten mixop1] @ [[op]]),
       [t'], [tit]
     )

--- a/spectec/src/il/ast.ml
+++ b/spectec/src/il/ast.ml
@@ -10,7 +10,8 @@ type nat = Z.t
 type text = string
 type id = string phrase
 
-type atom =
+type atom = (atom', string) note_phrase
+and atom' =
   | Atom of string               (* atomid *)
   | Infinity                     (* infinity *)
   | Bot                          (* `_|_` *)

--- a/spectec/src/il/eq.mli
+++ b/spectec/src/il/eq.mli
@@ -1,6 +1,8 @@
 open Ast
 
 val eq_id : id -> id -> bool
+val eq_atom : atom -> atom -> bool
+val eq_mixop : mixop -> mixop -> bool
 val eq_iter : iter -> iter -> bool
 val eq_iterexp : iterexp -> iterexp -> bool
 val eq_typ : typ -> typ -> bool

--- a/spectec/src/il/print.ml
+++ b/spectec/src/il/print.ml
@@ -12,7 +12,8 @@ let space f x = " " ^ f x ^ " "
 
 (* Operators *)
 
-let string_of_atom = function
+let string_of_atom atom =
+  match atom.it with
   | Atom atomid -> atomid
   | Infinity -> "infinity"
   | Bot -> "_|_"
@@ -81,7 +82,7 @@ let string_of_cmpop = function
   | GeOp _ -> ">="
 
 let string_of_mixop = function
-  | [Atom a]::tail when List.for_all ((=) []) tail -> a
+  | [{it = Atom a; _}]::tail when List.for_all ((=) []) tail -> a
   | mixop ->
     let s =
       String.concat "%" (List.map (

--- a/spectec/src/il/valid.ml
+++ b/spectec/src/il/valid.ml
@@ -60,12 +60,12 @@ let rebind _space env' id t =
   Env.add id.it t env'
 
 let find_field fs atom at =
-  match List.find_opt (fun (atom', _, _) -> atom' = atom) fs with
+  match List.find_opt (fun (atom', _, _) -> Eq.eq_atom atom' atom) fs with
   | Some (_, x, _) -> x
   | None -> error at ("unbound field `" ^ string_of_atom atom ^ "`")
 
 let find_case cases atom at =
-  match List.find_opt (fun (atom', _, _) -> atom' = atom) cases with
+  match List.find_opt (fun (atom', _, _) -> Eq.eq_atom atom' atom) cases with
   | Some (_, x, _) -> x
   | None -> error at ("unknown case `" ^ string_of_atom atom ^ "`")
 
@@ -324,7 +324,7 @@ and infer_exp env e : typ =
   | UnmixE (e1, op) ->
     let t1 = infer_exp env e1 in
     let op', t = as_mix_typ "expression" env Infer t1 e1.at in
-    if op <> op' then
+    if not (Eq.eq_mixop op op') then
       error e.at "invalid mixfix projection";
     t
   | OptE _ -> error e.at "cannot infer type of option"
@@ -439,7 +439,7 @@ and valid_exp env e t =
   | UnmixE (e1, op) ->
     let t1 = infer_exp env e1 in
     let op', t' = as_mix_typ "expression" env Infer t1 e1.at in
-    if op <> op' then
+    if not (Eq.eq_mixop op op') then
       error e.at "invalid mixfix projection";
     equiv_typ env t' t e.at
   | OptE eo ->
@@ -467,7 +467,7 @@ and valid_exp env e t =
 
 
 and valid_expmix env mixop e (mixop', t) at =
-  if mixop <> mixop' then
+  if not (Eq.eq_mixop mixop mixop') then
     error at (
       "mixin notation `" ^ string_of_mixop mixop ^
       "` does not match expected notation `" ^ string_of_mixop mixop' ^ "`"
@@ -486,7 +486,7 @@ and valid_tup_exp env s es ets =
   | _, _ -> true
 
 and valid_expfield env (atom1, e) (atom2, (_binds, t, _prems), _) =
-  if atom1 <> atom2 then error e.at "unexpected record field";
+  if not (Eq.eq_atom atom1 atom2) then error e.at "unexpected record field";
   valid_exp env e t
 
 and valid_path env p t : typ =

--- a/spectec/src/il2al/il2il.ml
+++ b/spectec/src/il2al/il2il.ml
@@ -133,7 +133,7 @@ let rec overlap e1 e2 = if eq_exp e1 e2 then e1 else
       ExtE (overlap e1 e2, path1, overlap e1' e2')
     | StrE efs1, StrE efs2 when List.map fst efs1 = List.map fst efs2 ->
       StrE (List.map2 (fun (a1, e1) (_, e2) -> (a1, overlap e1 e2)) efs1 efs2)
-    | DotE (e1, atom1), DotE (e2, atom2) when atom1 = atom2 ->
+    | DotE (e1, atom1), DotE (e2, atom2) when eq_atom atom1 atom2 ->
       DotE (overlap e1 e2, atom1)
     | CompE (e1, e1'), CompE (e2, e2') ->
       CompE (overlap e1 e2, overlap e1' e2')
@@ -141,7 +141,7 @@ let rec overlap e1 e2 = if eq_exp e1 e2 then e1 else
       LenE (overlap e1 e2)
     | TupE es1, TupE es2 when List.length es1 = List.length es2 ->
       TupE (List.map2 overlap es1 es2)
-    | MixE (mixop1, e1), MixE (mixop2, e2) when mixop1 = mixop2 ->
+    | MixE (mixop1, e1), MixE (mixop2, e2) when eq_mixop mixop1 mixop2 ->
       MixE (mixop1, overlap e1 e2)
     | CallE (id1, as1), CallE (id2, as2) when eq_id id1 id2 ->
       CallE (id1, List.map2 overlap_arg as1 as2)
@@ -149,7 +149,7 @@ let rec overlap e1 e2 = if eq_exp e1 e2 then e1 else
       IterE (overlap e1 e2, itere1)
     | ProjE (e1, i1), ProjE (e2, i2) when i1 = i2 ->
       ProjE (overlap e1 e2, i1)
-    | UnmixE (e1, op1), UnmixE (e2, op2) when op1 = op2 ->
+    | UnmixE (e1, op1), UnmixE (e2, op2) when eq_mixop op1 op2 ->
       UnmixE (overlap e1 e2, op1)
     | OptE (Some e1), OptE (Some e2) ->
       OptE (Some (overlap e1 e2))
@@ -159,7 +159,7 @@ let rec overlap e1 e2 = if eq_exp e1 e2 then e1 else
       ListE (List.map2 overlap es1 es2)
     | CatE (e1, e1'), CatE (e2, e2') ->
       CatE (overlap e1 e2, overlap e1' e2')
-    | CaseE (atom1, e1), CaseE (atom2, e2) when atom1 = atom2 ->
+    | CaseE (atom1, e1), CaseE (atom2, e2) when eq_atom atom1 atom2 ->
       CaseE (atom1, overlap e1 e2)
     | SubE (e1, typ1, typ1'), SubE (e2, typ2, typ2') when eq_typ typ1 typ2 && eq_typ typ1' typ2' ->
       SubE (overlap e1 e2, typ1, typ1')


### PR DESCRIPTION
@jaehyun1ee, FYI: this adds the type name note to IL atoms as well, as you suggested earlier. (Unfortunately, pattern matching on atoms in the translate module becomes more tedious through this.)