### PR TITLE
Rename mm to moduleinst

### DIFF
--- a/spectec/spec/wasm-1.0/9-module.watsup
+++ b/spectec/spec/wasm-1.0/9-module.watsup
@@ -34,15 +34,15 @@ def $mems(externval externval'*) = $mems(externval'*)
 ;; Definitions
 
 def $allocfunc(store, moduleinst, func) : (store, funcaddr)
-def $allocfunc(s, mm, func) = (s[.FUNCS =.. fi], |s.FUNCS|)
-  -- if fi = { TYPE mm.TYPES[x], MODULE mm, CODE func }
+def $allocfunc(s, moduleinst, func) = (s[.FUNCS =.. fi], |s.FUNCS|)
+  -- if fi = { TYPE moduleinst.TYPES[x], MODULE moduleinst, CODE func }
   -- if func = FUNC x local* expr
 
 def $allocfuncs(store, moduleinst, func*) : (store, funcaddr*)
-def $allocfuncs(s, mm, eps) = (s, eps)
-def $allocfuncs(s, mm, func func'*) = (s_2, fa fa'*)
-  -- if (s_1, fa) = $allocfunc(s, mm, func)
-  -- if (s_2, fa'*) = $allocfuncs(s_1, mm, func'*)
+def $allocfuncs(s, moduleinst, eps) = (s, eps)
+def $allocfuncs(s, moduleinst, func func'*) = (s_2, fa fa'*)
+  -- if (s_1, fa) = $allocfunc(s, moduleinst, func)
+  -- if (s_2, fa'*) = $allocfuncs(s_1, moduleinst, func'*)
 
 def $allocglobal(store, globaltype, val) : (store, globaladdr)
 def $allocglobal(s, globaltype, val) = (s[.GLOBALS =.. gi], |s.GLOBALS|)
@@ -85,7 +85,7 @@ def $instexport(fa*, ga*, ta*, ma*, EXPORT name (MEM x)) = { NAME name, VALUE (M
 
 
 def $allocmodule(store, module, externval*, val*) : (store, moduleinst)
-def $allocmodule(s, module, externval*, val*) = (s_4, mm)
+def $allocmodule(s, module, externval*, val*) = (s_4, moduleinst)
   -- if module =
     MODULE
       (TYPE ft)*
@@ -107,7 +107,7 @@ def $allocmodule(s, module, externval*, val*) = (s_4, mm)
   -- if ta* = $(|s.TABLES|+i_table)^(i_table<n_table)
   -- if ma* = $(|s.MEMS|+i_mem)^(i_mem<n_mem)
   -- if xi* = $instexport(fa_ex* fa*, ga_ex* ga*, ta_ex* ta*, ma_ex* ma*, export)*
-  -- if mm = {
+  -- if moduleinst = {
       TYPES ft*,
       FUNCS fa_ex* fa*,
       GLOBALS ga_ex* ga*,
@@ -115,7 +115,7 @@ def $allocmodule(s, module, externval*, val*) = (s_4, mm)
       MEMS ma_ex* ma*,
       EXPORTS xi*
     }
-  -- if (s_1, fa*) = $allocfuncs(s, mm, func^n_func)
+  -- if (s_1, fa*) = $allocfuncs(s, moduleinst, func^n_func)
   -- if (s_2, ga*) = $allocglobals(s_1, globaltype^n_global, val*)
   -- if (s_3, ta*) = $alloctables(s_2, tabletype^n_table)
   -- if (s_4, ma*) = $allocmems(s_3, memtype^n_mem)
@@ -126,16 +126,16 @@ def $allocmodule(s, module, externval*, val*) = (s_4, mm)
 ;;
 
 def $initelem(store, moduleinst, u32*, (funcaddr*)*) : store
-def $initelem(s, mm, eps, eps) = s
-def $initelem(s, mm, i i'*, (a*) (a'*)*) = s_2
-  -- if s_1 = s[.TABLES[mm.TABLES[0]].REFS[i:|a*|] = a*]
-  -- if s_2 = $initelem(s_1, mm, i'*, (a'*)*)
+def $initelem(s, moduleinst, eps, eps) = s
+def $initelem(s, moduleinst, i i'*, (a*) (a'*)*) = s_2
+  -- if s_1 = s[.TABLES[moduleinst.TABLES[0]].REFS[i:|a*|] = a*]
+  -- if s_2 = $initelem(s_1, moduleinst, i'*, (a'*)*)
 
 def $initdata(store, moduleinst, u32*, (byte*)*) : store
-def $initdata(s, mm, eps, eps) = s
-def $initdata(s, mm, i i'*, (b*) (b'*)*) = s_2
-  -- if s_1 = s[.MEMS[mm.MEMS[0]].BYTES[i:|b*|] = b*]
-  -- if s_2 = $initdata(s_1, mm, i'*, (b'*)*)
+def $initdata(s, moduleinst, eps, eps) = s
+def $initdata(s, moduleinst, i i'*, (b*) (b'*)*) = s_2
+  -- if s_1 = s[.MEMS[moduleinst.MEMS[0]].BYTES[i:|b*|] = b*]
+  -- if s_2 = $initdata(s_1, moduleinst, i'*, (b'*)*)
 
 def $instantiate(store, module, externval*) : config
 def $instantiate(s, module, externval*) = s_3; f; (CALL x')?
@@ -146,20 +146,20 @@ def $instantiate(s, module, externval*) = s_3; f; (CALL x')?
   -- if data* = (DATA expr_D b*)*
   -- if start? = (START x')?
   -- if n_F = |func*|
-  -- if mm_init = {
+  -- if moduleinst_init = {
       TYPES functype*,
       FUNCS $funcs(externval*) $(|s.FUNCS|+i_F)^(i_F<n_F),
       GLOBALS $globals(externval*)
     }
-  -- if f_init = { MODULE mm_init }
+  -- if f_init = { MODULE moduleinst_init }
   -- if z = s; f_init
   -- (Eval_expr : z; expr_G ~>* z; val)*
   -- (Eval_expr : z; expr_E ~>* z; (CONST I32 i_E))*
   -- (Eval_expr : z; expr_D ~>* z; (CONST I32 i_D))*
-  -- if (s_1, mm) = $allocmodule(s, module, externval*, val*)
-  -- if s_2 = $initelem(s_1, mm, i_E*, mm.FUNCS[x]**)
-  -- if s_3 = $initdata(s_2, mm, i_D*, b**)
-  -- if f = { MODULE mm }
+  -- if (s_1, moduleinst) = $allocmodule(s, module, externval*, val*)
+  -- if s_2 = $initelem(s_1, moduleinst, i_E*, moduleinst.FUNCS[x]**)
+  -- if s_3 = $initdata(s_2, moduleinst, i_D*, b**)
+  -- if f = { MODULE moduleinst }
 
 
 ;;

--- a/spectec/spec/wasm-2.0/9-module.watsup
+++ b/spectec/spec/wasm-2.0/9-module.watsup
@@ -34,15 +34,15 @@ def $mems(externval externval'*) = $mems(externval'*)
 ;; Definitions
 
 def $allocfunc(store, moduleinst, func) : (store, funcaddr)
-def $allocfunc(s, mm, func) = (s[.FUNCS =.. fi], |s.FUNCS|)
-  -- if fi = { TYPE mm.TYPES[x], MODULE mm, CODE func }
+def $allocfunc(s, moduleinst, func) = (s[.FUNCS =.. fi], |s.FUNCS|)
+  -- if fi = { TYPE moduleinst.TYPES[x], MODULE moduleinst, CODE func }
   -- if func = FUNC x local* expr
 
 def $allocfuncs(store, moduleinst, func*) : (store, funcaddr*)
-def $allocfuncs(s, mm, eps) = (s, eps)
-def $allocfuncs(s, mm, func func'*) = (s_2, fa fa'*)
-  -- if (s_1, fa) = $allocfunc(s, mm, func)
-  -- if (s_2, fa'*) = $allocfuncs(s_1, mm, func'*)
+def $allocfuncs(s, moduleinst, eps) = (s, eps)
+def $allocfuncs(s, moduleinst, func func'*) = (s_2, fa fa'*)
+  -- if (s_1, fa) = $allocfunc(s, moduleinst, func)
+  -- if (s_2, fa'*) = $allocfuncs(s_1, moduleinst, func'*)
 
 def $allocglobal(store, globaltype, val) : (store, globaladdr)
 def $allocglobal(s, globaltype, val) = (s[.GLOBALS =.. gi], |s.GLOBALS|)
@@ -105,7 +105,7 @@ def $instexport(fa*, ga*, ta*, ma*, EXPORT name (MEM x)) = { NAME name, VALUE (M
 
 
 def $allocmodule(store, module, externval*, val*, (ref*)*) : (store, moduleinst)
-def $allocmodule(s, module, externval*, val*, (ref*)*) = (s_6, mm)
+def $allocmodule(s, module, externval*, val*, (ref*)*) = (s_6, moduleinst)
   -- if module =
     MODULE
       (TYPE ft)*
@@ -129,7 +129,7 @@ def $allocmodule(s, module, externval*, val*, (ref*)*) = (s_6, mm)
   -- if ea* = $(|s.ELEMS|+i_elem)^(i_elem<n_elem)
   -- if da* = $(|s.DATAS|+i_data)^(i_data<n_data)
   -- if xi* = $instexport(fa_ex* fa*, ga_ex* ga*, ta_ex* ta*, ma_ex* ma*, export)*
-  -- if mm = {
+  -- if moduleinst = {
       TYPES ft*,
       FUNCS fa_ex* fa*,
       GLOBALS ga_ex* ga*,
@@ -139,7 +139,7 @@ def $allocmodule(s, module, externval*, val*, (ref*)*) = (s_6, mm)
       DATAS da*,
       EXPORTS xi*
     }
-  -- if (s_1, fa*) = $allocfuncs(s, mm, func^n_func)
+  -- if (s_1, fa*) = $allocfuncs(s, moduleinst, func^n_func)
   -- if (s_2, ga*) = $allocglobals(s_1, globaltype^n_global, val*)
   -- if (s_3, ta*) = $alloctables(s_2, tabletype^n_table)
   -- if (s_4, ma*) = $allocmems(s_3, memtype^n_mem)
@@ -174,17 +174,17 @@ def $instantiate(s, module, externval*) = s'; f; instr_E* instr_D* (CALL x)?
   -- if n_F = |func*|
   -- if n_E = |elem*|
   -- if n_D = |data*|
-  -- if mm_init = {
+  -- if moduleinst_init = {
        TYPES functype*,
        FUNCS $funcs(externval*) $(|s.FUNCS|+i_F)^(i_F<n_F),
        GLOBALS $globals(externval*)
      }
-  -- if f_init = { MODULE mm_init }
+  -- if f_init = { MODULE moduleinst_init }
   -- if z = s; f_init
   -- (Eval_expr : z; expr_G ~>* z; val)*
   -- (Eval_expr : z; expr_E ~>* z; ref)**
-  -- if (s', mm) = $allocmodule(s, module, externval*, val*, (ref*)*)
-  -- if f = { MODULE mm }
+  -- if (s', moduleinst) = $allocmodule(s, module, externval*, val*, (ref*)*)
+  -- if f = { MODULE moduleinst }
   -- if instr_E* = $concat_(instr, $runelem(elem*[i], i)^(i<n_E))
   -- if instr_D* = $concat_(instr, $rundata(data*[j], j)^(j<n_D))
 

--- a/spectec/spec/wasm-3.0/9-module.watsup
+++ b/spectec/spec/wasm-3.0/9-module.watsup
@@ -19,9 +19,9 @@ def $allocfunc(s, deftype, funccode, moduleinst) = (s ++ {FUNCS funcinst}, |s.FU
 
 def $allocfuncs(store, deftype*, funccode*, moduleinst*) : (store, funcaddr*) hint(show $allocfunc*#((%,%,%,%)))
 def $allocfuncs(s, eps, eps, eps) = (s, eps)
-def $allocfuncs(s, dt dt'*, funccode funccode'*, mm mm'*) = (s_2, fa fa'*)
-  -- if (s_1, fa) = $allocfunc(s, dt, funccode, mm)
-  -- if (s_2, fa'*) = $allocfuncs(s_1, dt'*, funccode'*, mm'*)
+def $allocfuncs(s, dt dt'*, funccode funccode'*, moduleinst moduleinst'*) = (s_2, fa fa'*)
+  -- if (s_1, fa) = $allocfunc(s, dt, funccode, moduleinst)
+  -- if (s_2, fa'*) = $allocfuncs(s_1, dt'*, funccode'*, moduleinst'*)
 
 def $allocglobal(store, globaltype, val) : (store, globaladdr)
 def $allocglobal(s, globaltype, val) = (s ++ {GLOBALS globalinst}, |s.GLOBALS|)

--- a/spectec/spec/wasm-3.0/9-module.watsup
+++ b/spectec/spec/wasm-3.0/9-module.watsup
@@ -160,7 +160,7 @@ def $instantiate(s, module, externval*) = s'; f; instr_E* instr_D* (CALL x)?
   -- if elem* = (ELEM reftype expr_E* elemmode)*
   -- if data* = (DATA byte* datamode)*
   -- if start? = (START x)?
-  ;; TODO: avoid this HACK and use mm directly, or built it fully incrementally
+  ;; TODO: avoid this HACK and use moduleinst directly, or built it fully incrementally
   -- if moduleinst_0 = {
       TYPES $alloctypes(type*),
       FUNCS $funcsxv(externval*) ($(|s.FUNCS|+i_F))^(i_F<|func*|),
@@ -170,9 +170,8 @@ def $instantiate(s, module, externval*) = s'; f; instr_E* instr_D* (CALL x)?
   -- (Eval_expr : z; expr_G ~>* z; val_G)*
   -- (Eval_expr : z; expr_T ~>* z; ref_T)*
   -- (Eval_expr : z; expr_E ~>* z; ref_E)**
-  ;; TODO: rename mm to moduleinst (causes stack overflow in interpreter!)
-  -- if (s', mm) = $allocmodule(s, module, externval*, val_G*, ref_T*, (ref_E*)*)
-  -- if f = {MODULE mm}  ;; TODO: inline
+  -- if (s', moduleinst) = $allocmodule(s, module, externval*, val_G*, ref_T*, (ref_E*)*)
+  -- if f = {MODULE moduleinst}  ;; TODO: inline
   -- if instr_E* = $concat_(instr, $runelem_(i_E, elem*[i_E])^(i_E<|elem*|))
   -- if instr_D* = $concat_(instr, $rundata_(i_D, data*[i_D])^(i_D<|data*|))
   ;;-- if instr_S? = (CALL x)?  ;; TODO: use above

--- a/spectec/src/il2al/manual.ml
+++ b/spectec/src/il2al/manual.ml
@@ -1,3 +1,4 @@
+open Util.Source
 open Al
 open Ast
 open Al_util
@@ -128,7 +129,7 @@ let return_instrs_of_instantiate config =
       frameE (Some (numE Z.zero), frame),
       listE ([ caseE (atom_of_name "FRAME_" "admininstr", []) ]), rhs
     );
-    returnI (Some (tupE [ store; varE "moduleinst" ]))
+    returnI (Some (tupE [ store; accE (frame, DotP (atom_of_name "MODULE" "") $ no_region) ]))
   ]
 let return_instrs_of_invoke config =
   let _, frame, rhs = config in

--- a/spectec/src/il2al/manual.ml
+++ b/spectec/src/il2al/manual.ml
@@ -128,7 +128,7 @@ let return_instrs_of_instantiate config =
       frameE (Some (numE Z.zero), frame),
       listE ([ caseE (atom_of_name "FRAME_" "admininstr", []) ]), rhs
     );
-    returnI (Some (tupE [ store; varE "mm" ]))
+    returnI (Some (tupE [ store; varE "moduleinst" ]))
   ]
 let return_instrs_of_invoke config =
   let _, frame, rhs = config in

--- a/spectec/test-frontend/TEST.md
+++ b/spectec/test-frontend/TEST.md
@@ -5535,10 +5535,10 @@ rec {
 def $allocfuncs(store : store, deftype*, funccode*, moduleinst*) : (store, funcaddr*)
   ;; 9-module.watsup:21.1-21.45
   def $allocfuncs{s : store}(s, [], [], []) = (s, [])
-  ;; 9-module.watsup:22.1-24.63
-  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, mm : moduleinst, mm'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [mm] :: mm'*{mm' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
-    -- if ((s_1, fa) = $allocfunc(s, dt, funccode, mm))
-    -- if ((s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, mm'*{mm' : moduleinst}))
+  ;; 9-module.watsup:22.1-24.71
+  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, moduleinst : moduleinst, moduleinst'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [moduleinst] :: moduleinst'*{moduleinst' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
+    -- if ((s_1, fa) = $allocfunc(s, dt, funccode, moduleinst))
+    -- if ((s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, moduleinst'*{moduleinst' : moduleinst}))
 }
 
 ;; 9-module.watsup
@@ -5702,7 +5702,7 @@ def $rundata_(dataidx : dataidx, data : data) : instr*
 ;; 9-module.watsup
 def $instantiate(store : store, module : module, externval*) : config
   ;; 9-module.watsup
-  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, mm : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
+  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, moduleinst : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
     -- if (module = MODULE_module(type*{type : type}, import*{import : import}, func*{func : func}, global*{global : global}, table*{table : table}, mem*{mem : mem}, elem*{elem : elem}, data*{data : data}, start?{start : start}, export*{export : export}))
     -- if (global*{global : global} = GLOBAL_global(globaltype, expr_G)*{expr_G : expr, globaltype : globaltype})
     -- if (table*{table : table} = TABLE_table(tabletype, expr_T)*{expr_T : expr, tabletype : tabletype})
@@ -5714,8 +5714,8 @@ def $instantiate(store : store, module : module, externval*) : config
     -- (Eval_expr: `%;%~>*%;%`(z, expr_G, z, [val_G]))*{expr_G : expr, val_G : val}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_T, z, [(ref_T : ref <: val)]))*{expr_T : expr, ref_T : ref}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_E, z, [(ref_E : ref <: val)]))*{expr_E : expr, ref_E : ref}*{expr_E : expr, ref_E : ref}
-    -- if ((s', mm) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref}))
-    -- if (f = {LOCALS [], MODULE mm})
+    -- if ((s', moduleinst) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref}))
+    -- if (f = {LOCALS [], MODULE moduleinst})
     -- if (instr_E*{instr_E : instr} = $concat_(syntax instr, $runelem_(`%`_elemidx(i_E), elem*{elem : elem}[i_E])^(i_E<|elem*{elem : elem}|){i_E : nat}))
     -- if (instr_D*{instr_D : instr} = $concat_(syntax instr, $rundata_(`%`_dataidx(i_D), data*{data : data}[i_D])^(i_D<|data*{data : data}|){i_D : nat}))
 

--- a/spectec/test-latex/TEST.md
+++ b/spectec/test-latex/TEST.md
@@ -7904,9 +7904,9 @@ $$
 $$
 \begin{array}{@{}lcl@{}l@{}}
 {{{\mathrm{allocfunc}}^\ast}}{(s,\, \epsilon,\, \epsilon,\, \epsilon)} &=& (s,\, \epsilon) \\
-{{{\mathrm{allocfunc}}^\ast}}{(s,\, {\mathit{dt}}~{{\mathit{dt}'}^\ast},\, {\mathit{code}}~{{{\mathit{code}}'}^\ast},\, {\mathit{mm}}~{{\mathit{mm}'}^\ast})} &=& (s_2,\, {\mathit{fa}}~{{\mathit{fa}'}^\ast})
-  &\qquad \mbox{if}~(s_1,\, {\mathit{fa}}) = {\mathrm{allocfunc}}(s, {\mathit{dt}}, {\mathit{code}}, {\mathit{mm}}) \\
-  &&&\qquad {\land}~(s_2,\, {{\mathit{fa}'}^\ast}) = {{{\mathrm{allocfunc}}^\ast}}{(s_1,\, {{\mathit{dt}'}^\ast},\, {{{\mathit{code}}'}^\ast},\, {{\mathit{mm}'}^\ast})} \\
+{{{\mathrm{allocfunc}}^\ast}}{(s,\, {\mathit{dt}}~{{\mathit{dt}'}^\ast},\, {\mathit{code}}~{{{\mathit{code}}'}^\ast},\, {\mathit{moduleinst}}~{{\mathit{moduleinst}'}^\ast})} &=& (s_2,\, {\mathit{fa}}~{{\mathit{fa}'}^\ast})
+  &\qquad \mbox{if}~(s_1,\, {\mathit{fa}}) = {\mathrm{allocfunc}}(s, {\mathit{dt}}, {\mathit{code}}, {\mathit{moduleinst}}) \\
+  &&&\qquad {\land}~(s_2,\, {{\mathit{fa}'}^\ast}) = {{{\mathrm{allocfunc}}^\ast}}{(s_1,\, {{\mathit{dt}'}^\ast},\, {{{\mathit{code}}'}^\ast},\, {{\mathit{moduleinst}'}^\ast})} \\
 \end{array}
 $$
 
@@ -8094,9 +8094,9 @@ $$
    \multicolumn{4}{@{}l@{}}{\qquad\quad {\land}~(z ; {\mathit{expr}}_{\mathsf{g}} \hookrightarrow^\ast z ; {\mathit{val}}_{\mathsf{g}})^\ast} \\
    \multicolumn{4}{@{}l@{}}{\qquad\quad {\land}~(z ; {\mathit{expr}}_{\mathsf{t}} \hookrightarrow^\ast z ; {\mathit{ref}}_{\mathsf{t}})^\ast} \\
    \multicolumn{4}{@{}l@{}}{\qquad\quad {\land}~{(z ; {\mathit{expr}}_{\mathsf{e}} \hookrightarrow^\ast z ; {\mathit{ref}}_{\mathsf{e}})^\ast}^\ast} \\
-   \multicolumn{4}{@{}l@{}}{\qquad\quad {\land}~({s'},\, {\mathit{mm}}) = {\mathrm{allocmodule}}(s, {\mathit{module}}, {{\mathit{externval}}^\ast}, {{\mathit{val}}_{\mathsf{g}}^\ast}, {{\mathit{ref}}_{\mathsf{t}}^\ast}, {({{\mathit{ref}}_{\mathsf{e}}^\ast})^\ast})} \\
+   \multicolumn{4}{@{}l@{}}{\qquad\quad {\land}~({s'},\, {\mathit{moduleinst}}) = {\mathrm{allocmodule}}(s, {\mathit{module}}, {{\mathit{externval}}^\ast}, {{\mathit{val}}_{\mathsf{g}}^\ast}, {{\mathit{ref}}_{\mathsf{t}}^\ast}, {({{\mathit{ref}}_{\mathsf{e}}^\ast})^\ast})} \\
    \multicolumn{4}{@{}l@{}}{\qquad\quad {\land}~f = \{ \begin{array}[t]{@{}l@{}}
-\mathsf{module}~{\mathit{mm}} \}\end{array}} \\
+\mathsf{module}~{\mathit{moduleinst}} \}\end{array}} \\
    \multicolumn{4}{@{}l@{}}{\qquad\quad {\land}~{{\mathit{instr}}_{\mathsf{e}}^\ast} = {\mathrm{concat}}({{{\mathrm{runelem}}}_{i_{\mathsf{e}}}({{\mathit{elem}}^\ast}{}[i_{\mathsf{e}}])^{i_{\mathsf{e}}<{|{{\mathit{elem}}^\ast}|}}})} \\
    \multicolumn{4}{@{}l@{}}{\qquad\quad {\land}~{{\mathit{instr}}_{\mathsf{d}}^\ast} = {\mathrm{concat}}({{{\mathrm{rundata}}}_{i_{\mathsf{d}}}({{\mathit{data}}^\ast}{}[i_{\mathsf{d}}])^{i_{\mathsf{d}}<{|{{\mathit{data}}^\ast}|}}})} \\
 \end{array}

--- a/spectec/test-middlend/TEST.md
+++ b/spectec/test-middlend/TEST.md
@@ -5525,10 +5525,10 @@ rec {
 def $allocfuncs(store : store, deftype*, funccode*, moduleinst*) : (store, funcaddr*)
   ;; 9-module.watsup:21.1-21.45
   def $allocfuncs{s : store}(s, [], [], []) = (s, [])
-  ;; 9-module.watsup:22.1-24.63
-  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, mm : moduleinst, mm'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [mm] :: mm'*{mm' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
-    -- if ((s_1, fa) = $allocfunc(s, dt, funccode, mm))
-    -- if ((s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, mm'*{mm' : moduleinst}))
+  ;; 9-module.watsup:22.1-24.71
+  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, moduleinst : moduleinst, moduleinst'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [moduleinst] :: moduleinst'*{moduleinst' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
+    -- if ((s_1, fa) = $allocfunc(s, dt, funccode, moduleinst))
+    -- if ((s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, moduleinst'*{moduleinst' : moduleinst}))
 }
 
 ;; 9-module.watsup
@@ -5692,7 +5692,7 @@ def $rundata_(dataidx : dataidx, data : data) : instr*
 ;; 9-module.watsup
 def $instantiate(store : store, module : module, externval*) : config
   ;; 9-module.watsup
-  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, mm : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
+  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, moduleinst : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
     -- if (module = MODULE_module(type*{type : type}, import*{import : import}, func*{func : func}, global*{global : global}, table*{table : table}, mem*{mem : mem}, elem*{elem : elem}, data*{data : data}, start?{start : start}, export*{export : export}))
     -- if (global*{global : global} = GLOBAL_global(globaltype, expr_G)*{expr_G : expr, globaltype : globaltype})
     -- if (table*{table : table} = TABLE_table(tabletype, expr_T)*{expr_T : expr, tabletype : tabletype})
@@ -5704,8 +5704,8 @@ def $instantiate(store : store, module : module, externval*) : config
     -- (Eval_expr: `%;%~>*%;%`(z, expr_G, z, [val_G]))*{expr_G : expr, val_G : val}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_T, z, [(ref_T : ref <: val)]))*{expr_T : expr, ref_T : ref}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_E, z, [(ref_E : ref <: val)]))*{expr_E : expr, ref_E : ref}*{expr_E : expr, ref_E : ref}
-    -- if ((s', mm) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref}))
-    -- if (f = {LOCALS [], MODULE mm})
+    -- if ((s', moduleinst) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref}))
+    -- if (f = {LOCALS [], MODULE moduleinst})
     -- if (instr_E*{instr_E : instr} = $concat_(syntax instr, $runelem_(`%`_elemidx(i_E), elem*{elem : elem}[i_E])^(i_E<|elem*{elem : elem}|){i_E : nat}))
     -- if (instr_D*{instr_D : instr} = $concat_(syntax instr, $rundata_(`%`_dataidx(i_D), data*{data : data}[i_D])^(i_D<|data*{data : data}|){i_D : nat}))
 
@@ -11367,10 +11367,10 @@ rec {
 def $allocfuncs(store : store, deftype*, funccode*, moduleinst*) : (store, funcaddr*)
   ;; 9-module.watsup:21.1-21.45
   def $allocfuncs{s : store}(s, [], [], []) = (s, [])
-  ;; 9-module.watsup:22.1-24.63
-  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, mm : moduleinst, mm'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [mm] :: mm'*{mm' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
-    -- if ((s_1, fa) = $allocfunc(s, dt, funccode, mm))
-    -- if ((s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, mm'*{mm' : moduleinst}))
+  ;; 9-module.watsup:22.1-24.71
+  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, moduleinst : moduleinst, moduleinst'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [moduleinst] :: moduleinst'*{moduleinst' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
+    -- if ((s_1, fa) = $allocfunc(s, dt, funccode, moduleinst))
+    -- if ((s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, moduleinst'*{moduleinst' : moduleinst}))
 }
 
 ;; 9-module.watsup
@@ -11534,7 +11534,7 @@ def $rundata_(dataidx : dataidx, data : data) : instr*
 ;; 9-module.watsup
 def $instantiate(store : store, module : module, externval*) : config
   ;; 9-module.watsup
-  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, mm : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
+  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, moduleinst : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
     -- if (module = MODULE_module(type*{type : type}, import*{import : import}, func*{func : func}, global*{global : global}, table*{table : table}, mem*{mem : mem}, elem*{elem : elem}, data*{data : data}, start?{start : start}, export*{export : export}))
     -- if (global*{global : global} = GLOBAL_global(globaltype, expr_G)*{expr_G : expr, globaltype : globaltype})
     -- if (table*{table : table} = TABLE_table(tabletype, expr_T)*{expr_T : expr, tabletype : tabletype})
@@ -11546,8 +11546,8 @@ def $instantiate(store : store, module : module, externval*) : config
     -- (Eval_expr: `%;%~>*%;%`(z, expr_G, z, [val_G]))*{expr_G : expr, val_G : val}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_T, z, [(ref_T : ref <: val)]))*{expr_T : expr, ref_T : ref}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_E, z, [(ref_E : ref <: val)]))*{expr_E : expr, ref_E : ref}*{expr_E : expr, ref_E : ref}
-    -- if ((s', mm) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref}))
-    -- if (f = {LOCALS [], MODULE mm})
+    -- if ((s', moduleinst) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref}))
+    -- if (f = {LOCALS [], MODULE moduleinst})
     -- if (instr_E*{instr_E : instr} = $concat_(syntax instr, $runelem_(`%`_elemidx(i_E), elem*{elem : elem}[i_E])^(i_E<|elem*{elem : elem}|){i_E : nat}))
     -- if (instr_D*{instr_D : instr} = $concat_(syntax instr, $rundata_(`%`_dataidx(i_D), data*{data : data}[i_D])^(i_D<|data*{data : data}|){i_D : nat}))
 
@@ -17209,10 +17209,10 @@ rec {
 def $allocfuncs(store : store, deftype*, funccode*, moduleinst*) : (store, funcaddr*)
   ;; 9-module.watsup:21.1-21.45
   def $allocfuncs{s : store}(s, [], [], []) = (s, [])
-  ;; 9-module.watsup:22.1-24.63
-  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, mm : moduleinst, mm'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [mm] :: mm'*{mm' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
-    -- if ((s_1, fa) = $allocfunc(s, dt, funccode, mm))
-    -- if ((s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, mm'*{mm' : moduleinst}))
+  ;; 9-module.watsup:22.1-24.71
+  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, moduleinst : moduleinst, moduleinst'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [moduleinst] :: moduleinst'*{moduleinst' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
+    -- if ((s_1, fa) = $allocfunc(s, dt, funccode, moduleinst))
+    -- if ((s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, moduleinst'*{moduleinst' : moduleinst}))
 }
 
 ;; 9-module.watsup
@@ -17376,7 +17376,7 @@ def $rundata_(dataidx : dataidx, data : data) : instr*
 ;; 9-module.watsup
 def $instantiate(store : store, module : module, externval*) : config
   ;; 9-module.watsup
-  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, mm : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
+  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, moduleinst : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
     -- if (module = MODULE_module(type*{type : type}, import*{import : import}, func*{func : func}, global*{global : global}, table*{table : table}, mem*{mem : mem}, elem*{elem : elem}, data*{data : data}, start?{start : start}, export*{export : export}))
     -- if (global*{global : global} = GLOBAL_global(globaltype, expr_G)*{expr_G : expr, globaltype : globaltype})
     -- if (table*{table : table} = TABLE_table(tabletype, expr_T)*{expr_T : expr, tabletype : tabletype})
@@ -17388,8 +17388,8 @@ def $instantiate(store : store, module : module, externval*) : config
     -- (Eval_expr: `%;%~>*%;%`(z, expr_G, z, [val_G]))*{expr_G : expr, val_G : val}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_T, z, [(ref_T : ref <: val)]))*{expr_T : expr, ref_T : ref}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_E, z, [(ref_E : ref <: val)]))*{expr_E : expr, ref_E : ref}*{expr_E : expr, ref_E : ref}
-    -- if ((s', mm) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref}))
-    -- if (f = {LOCALS [], MODULE mm})
+    -- if ((s', moduleinst) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref}))
+    -- if (f = {LOCALS [], MODULE moduleinst})
     -- if (instr_E*{instr_E : instr} = $concat_(syntax instr, $runelem_(`%`_elemidx(i_E), elem*{elem : elem}[i_E])^(i_E<|elem*{elem : elem}|){i_E : nat}))
     -- if (instr_D*{instr_D : instr} = $concat_(syntax instr, $rundata_(`%`_dataidx(i_D), data*{data : data}[i_D])^(i_D<|data*{data : data}|){i_D : nat}))
 
@@ -23213,10 +23213,10 @@ rec {
 def $allocfuncs(store : store, deftype*, funccode*, moduleinst*) : (store, funcaddr*)
   ;; 9-module.watsup:21.1-21.45
   def $allocfuncs{s : store}(s, [], [], []) = (s, [])
-  ;; 9-module.watsup:22.1-24.63
-  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, mm : moduleinst, mm'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [mm] :: mm'*{mm' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
-    -- if ((s_1, fa) = $allocfunc(s, dt, funccode, mm))
-    -- if ((s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, mm'*{mm' : moduleinst}))
+  ;; 9-module.watsup:22.1-24.71
+  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, moduleinst : moduleinst, moduleinst'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [moduleinst] :: moduleinst'*{moduleinst' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
+    -- if ((s_1, fa) = $allocfunc(s, dt, funccode, moduleinst))
+    -- if ((s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, moduleinst'*{moduleinst' : moduleinst}))
 }
 
 ;; 9-module.watsup
@@ -23380,7 +23380,7 @@ def $rundata_(dataidx : dataidx, data : data) : instr*
 ;; 9-module.watsup
 def $instantiate(store : store, module : module, externval*) : config
   ;; 9-module.watsup
-  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, mm : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
+  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, moduleinst : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
     -- if (module = MODULE_module(type*{type : type}, import*{import : import}, func*{func : func}, global*{global : global}, table*{table : table}, mem*{mem : mem}, elem*{elem : elem}, data*{data : data}, start?{start : start}, export*{export : export}))
     -- if (global*{global : global} = GLOBAL_global(globaltype, expr_G)*{expr_G : expr, globaltype : globaltype})
     -- if (table*{table : table} = TABLE_table(tabletype, expr_T)*{expr_T : expr, tabletype : tabletype})
@@ -23392,8 +23392,8 @@ def $instantiate(store : store, module : module, externval*) : config
     -- (Eval_expr: `%;%~>*%;%`(z, expr_G, z, [val_G]))*{expr_G : expr, val_G : val}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_T, z, [(ref_T : ref <: val)]))*{expr_T : expr, ref_T : ref}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_E, z, [(ref_E : ref <: val)]))*{expr_E : expr, ref_E : ref}*{expr_E : expr, ref_E : ref}
-    -- if ((s', mm) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref}))
-    -- if (f = {LOCALS [], MODULE mm})
+    -- if ((s', moduleinst) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref}))
+    -- if (f = {LOCALS [], MODULE moduleinst})
     -- if (instr_E*{instr_E : instr} = $concat_(syntax instr, $runelem_(`%`_elemidx(i_E), elem*{elem : elem}[i_E])^(i_E<|elem*{elem : elem}|){i_E : nat}))
     -- if (instr_D*{instr_D : instr} = $concat_(syntax instr, $rundata_(`%`_dataidx(i_D), data*{data : data}[i_D])^(i_D<|data*{data : data}|){i_D : nat}))
 
@@ -29281,10 +29281,10 @@ rec {
 def $allocfuncs(store : store, deftype*, funccode*, moduleinst*) : (store, funcaddr*)
   ;; 9-module.watsup:21.1-21.45
   def $allocfuncs{s : store}(s, [], [], []) = (s, [])
-  ;; 9-module.watsup:22.1-24.63
-  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, mm : moduleinst, mm'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [mm] :: mm'*{mm' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
-    -- where (s_1, fa) = $allocfunc(s, dt, funccode, mm)
-    -- where (s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, mm'*{mm' : moduleinst})
+  ;; 9-module.watsup:22.1-24.71
+  def $allocfuncs{s : store, dt : deftype, dt'* : deftype*, funccode : funccode, funccode'* : funccode*, moduleinst : moduleinst, moduleinst'* : moduleinst*, s_2 : store, fa : funcaddr, fa'* : funcaddr*, s_1 : store}(s, [dt] :: dt'*{dt' : deftype}, [funccode] :: funccode'*{funccode' : funccode}, [moduleinst] :: moduleinst'*{moduleinst' : moduleinst}) = (s_2, [fa] :: fa'*{fa' : funcaddr})
+    -- where (s_1, fa) = $allocfunc(s, dt, funccode, moduleinst)
+    -- where (s_2, fa'*{fa' : funcaddr}) = $allocfuncs(s_1, dt'*{dt' : deftype}, funccode'*{funccode' : funccode}, moduleinst'*{moduleinst' : moduleinst})
 }
 
 ;; 9-module.watsup
@@ -29448,7 +29448,7 @@ def $rundata_(dataidx : dataidx, data : data) : instr*
 ;; 9-module.watsup
 def $instantiate(store : store, module : module, externval*) : config
   ;; 9-module.watsup
-  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, mm : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
+  def $instantiate{s : store, module : module, externval* : externval*, s' : store, f : frame, instr_E* : instr*, instr_D* : instr*, x? : idx?, type* : type*, import* : import*, func* : func*, global* : global*, table* : table*, mem* : mem*, elem* : elem*, data* : data*, start? : start?, export* : export*, globaltype* : globaltype*, expr_G* : expr*, tabletype* : tabletype*, expr_T* : expr*, reftype* : reftype*, expr_E** : expr**, elemmode* : elemmode*, byte** : byte**, datamode* : datamode*, moduleinst_0 : moduleinst, i_F^|func*{func : func}| : nat^|func*{func : func}|, z : state, val_G* : val*, ref_T* : ref*, ref_E** : ref**, moduleinst : moduleinst, i_E^|elem*{elem : elem}| : nat^|elem*{elem : elem}|, i_D^|data*{data : data}| : nat^|data*{data : data}|}(s, module, externval*{externval : externval}) = `%;%`_config(`%;%`_state(s', f), instr_E*{instr_E : instr} :: instr_D*{instr_D : instr} :: CALL_instr(x)?{x : funcidx})
     -- where MODULE_module(type*{type : type}, import*{import : import}, func*{func : func}, global*{global : global}, table*{table : table}, mem*{mem : mem}, elem*{elem : elem}, data*{data : data}, start?{start : start}, export*{export : export}) = module
     -- where instr_D*{instr_D : instr} = $concat_(syntax instr, $rundata_(`%`_dataidx(i_D), data*{data : data}[i_D])^(i_D<|data*{data : data}|){i_D : nat})
     -- where instr_E*{instr_E : instr} = $concat_(syntax instr, $runelem_(`%`_elemidx(i_E), elem*{elem : elem}[i_E])^(i_E<|elem*{elem : elem}|){i_E : nat})
@@ -29462,8 +29462,8 @@ def $instantiate(store : store, module : module, externval*) : config
     -- (Eval_expr: `%;%~>*%;%`(z, expr_G, z, [val_G]))*{expr_G : expr, val_G : val}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_T, z, [(ref_T : ref <: val)]))*{expr_T : expr, ref_T : ref}
     -- (Eval_expr: `%;%~>*%;%`(z, expr_E, z, [(ref_E : ref <: val)]))*{expr_E : expr, ref_E : ref}*{expr_E : expr, ref_E : ref}
-    -- where (s', mm) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref})
-    -- where f = {LOCALS [], MODULE mm}
+    -- where (s', moduleinst) = $allocmodule(s, module, externval*{externval : externval}, val_G*{val_G : val}, ref_T*{ref_T : ref}, ref_E*{ref_E : ref}*{ref_E : ref})
+    -- where f = {LOCALS [], MODULE moduleinst}
 
 ;; 9-module.watsup
 def $invoke(store : store, funcaddr : funcaddr, val*) : config

--- a/spectec/test-prose/TEST.md
+++ b/spectec/test-prose/TEST.md
@@ -729,20 +729,20 @@ mems exter_u0*
 4. Let [externval] ++ externval'* be exter_u0*.
 5. Return $mems(externval'*).
 
-allocfunc mm func
+allocfunc moduleinst func
 1. Assert: Due to validation, func is of the case FUNC.
 2. Let (FUNC x local* expr) be func.
-3. Let fi be { TYPE: mm.TYPES[x]; MODULE: mm; CODE: func; }.
+3. Let fi be { TYPE: moduleinst.TYPES[x]; MODULE: moduleinst; CODE: func; }.
 4. Let a be |s.FUNCS|.
 5. Append fi to the s.FUNCS.
 6. Return a.
 
-allocfuncs mm func_u0*
+allocfuncs moduleinst func_u0*
 1. If (func_u0* is []), then:
   a. Return [].
 2. Let [func] ++ func'* be func_u0*.
-3. Let fa be $allocfunc(mm, func).
-4. Let fa'* be $allocfuncs(mm, func'*).
+3. Let fa be $allocfunc(moduleinst, func).
+4. Let fa'* be $allocfuncs(moduleinst, func'*).
 5. Return [fa] ++ fa'*.
 
 allocglobal globaltype val
@@ -821,8 +821,8 @@ allocmodule module externval* val*
 13. Let ta* be (|s.TABLES| + i_table)^(i_table<n_table).
 14. Let ma* be (|s.MEMS| + i_mem)^(i_mem<n_mem).
 15. Let xi* be $instexport(fa_ex* ++ fa*, ga_ex* ++ ga*, ta_ex* ++ ta*, ma_ex* ++ ma*, export)*.
-16. Let mm be { TYPES: ft*; FUNCS: fa_ex* ++ fa*; GLOBALS: ga_ex* ++ ga*; TABLES: ta_ex* ++ ta*; MEMS: ma_ex* ++ ma*; EXPORTS: xi*; }.
-17. Let y_0 be $allocfuncs(mm, func^n_func).
+16. Let moduleinst be { TYPES: ft*; FUNCS: fa_ex* ++ fa*; GLOBALS: ga_ex* ++ ga*; TABLES: ta_ex* ++ ta*; MEMS: ma_ex* ++ ma*; EXPORTS: xi*; }.
+17. Let y_0 be $allocfuncs(moduleinst, func^n_func).
 18. Assert: Due to validation, (y_0 is fa*).
 19. Let y_0 be $allocglobals(globaltype^n_global, val*).
 20. Assert: Due to validation, (y_0 is ga*).
@@ -830,28 +830,28 @@ allocmodule module externval* val*
 22. Assert: Due to validation, (y_0 is ta*).
 23. Let y_0 be $allocmems(memtype^n_mem).
 24. Assert: Due to validation, (y_0 is ma*).
-25. Return mm.
+25. Return moduleinst.
 
-initelem mm u32_u0* funca_u1*
+initelem moduleinst u32_u0* funca_u1*
 1. If ((u32_u0* is []) and (funca_u1* is [])), then:
   a. Return.
 2. Assert: Due to validation, (|funca_u1*| ≥ 1).
 3. Let [a*] ++ a'** be funca_u1*.
 4. Assert: Due to validation, (|u32_u0*| ≥ 1).
 5. Let [i] ++ i'* be u32_u0*.
-6. Replace s.TABLES[mm.TABLES[0]].REFS[i : |a*|] with ?(a)*.
-7. Perform $initelem(mm, i'*, a'**).
+6. Replace s.TABLES[moduleinst.TABLES[0]].REFS[i : |a*|] with ?(a)*.
+7. Perform $initelem(moduleinst, i'*, a'**).
 8. Return.
 
-initdata mm u32_u0* byte_u1*
+initdata moduleinst u32_u0* byte_u1*
 1. If ((u32_u0* is []) and (byte_u1* is [])), then:
   a. Return.
 2. Assert: Due to validation, (|byte_u1*| ≥ 1).
 3. Let [b*] ++ b'** be byte_u1*.
 4. Assert: Due to validation, (|u32_u0*| ≥ 1).
 5. Let [i] ++ i'* be u32_u0*.
-6. Replace s.MEMS[mm.MEMS[0]].BYTES[i : |b*|] with b*.
-7. Perform $initdata(mm, i'*, b'**).
+6. Replace s.MEMS[moduleinst.MEMS[0]].BYTES[i : |b*|] with b*.
+7. Perform $initdata(moduleinst, i'*, b'**).
 8. Return.
 
 instantiate module externval*
@@ -863,8 +863,8 @@ instantiate module externval*
 6. Let (DATA expr_D b*)* be data*.
 7. Let (ELEM expr_E x*)* be elem*.
 8. Let (GLOBAL globaltype expr_G)* be global*.
-9. Let mm_init be { TYPES: functype*; FUNCS: $funcs(externval*) ++ (|s.FUNCS| + i_F)^(i_F<n_F); GLOBALS: $globals(externval*); TABLES: []; MEMS: []; EXPORTS: []; }.
-10. Let f_init be { LOCALS: []; MODULE: mm_init; }.
+9. Let moduleinst_init be { TYPES: functype*; FUNCS: $funcs(externval*) ++ (|s.FUNCS| + i_F)^(i_F<n_F); GLOBALS: $globals(externval*); TABLES: []; MEMS: []; EXPORTS: []; }.
+10. Let f_init be { LOCALS: []; MODULE: moduleinst_init; }.
 11. Let z be f_init.
 12. Push the activation of z to the stack.
 13. Let [(I32.CONST i_D)]* be $eval_expr(expr_D)*.
@@ -875,16 +875,16 @@ instantiate module externval*
 18. Push the activation of z to the stack.
 19. Let [val]* be $eval_expr(expr_G)*.
 20. Pop the activation of z from the stack.
-21. Let mm be $allocmodule(module, externval*, val*).
-22. Let f be { LOCALS: []; MODULE: mm; }.
-23. Perform $initelem(mm, i_E*, mm.FUNCS[x]**).
-24. Perform $initdata(mm, i_D*, b**).
+21. Let moduleinst be $allocmodule(module, externval*, val*).
+22. Let f be { LOCALS: []; MODULE: moduleinst; }.
+23. Perform $initelem(moduleinst, i_E*, moduleinst.FUNCS[x]**).
+24. Perform $initdata(moduleinst, i_D*, b**).
 25. Push the activation of f with arity 0 to the stack.
 26. If x' is defined, then:
   a. Let ?(x'_0) be x'.
   b. Execute the instruction (CALL x'_0).
 27. Pop the activation of f with arity 0 from the stack.
-28. Return mm.
+28. Return moduleinst.
 
 invoke fa val^n
 1. Let f be { LOCALS: []; MODULE: { TYPES: []; FUNCS: []; GLOBALS: []; TABLES: []; MEMS: []; EXPORTS: []; }; }.
@@ -2622,20 +2622,20 @@ mems exter_u0*
 4. Let [externval] ++ externval'* be exter_u0*.
 5. Return $mems(externval'*).
 
-allocfunc mm func
+allocfunc moduleinst func
 1. Assert: Due to validation, func is of the case FUNC.
 2. Let (FUNC x local* expr) be func.
-3. Let fi be { TYPE: mm.TYPES[x]; MODULE: mm; CODE: func; }.
+3. Let fi be { TYPE: moduleinst.TYPES[x]; MODULE: moduleinst; CODE: func; }.
 4. Let a be |s.FUNCS|.
 5. Append fi to the s.FUNCS.
 6. Return a.
 
-allocfuncs mm func_u0*
+allocfuncs moduleinst func_u0*
 1. If (func_u0* is []), then:
   a. Return [].
 2. Let [func] ++ func'* be func_u0*.
-3. Let fa be $allocfunc(mm, func).
-4. Let fa'* be $allocfuncs(mm, func'*).
+3. Let fa be $allocfunc(moduleinst, func).
+4. Let fa'* be $allocfuncs(moduleinst, func'*).
 5. Return [fa] ++ fa'*.
 
 allocglobal globaltype val
@@ -2749,8 +2749,8 @@ allocmodule module externval* val* ref**
 17. Let ea* be (|s.ELEMS| + i_elem)^(i_elem<n_elem).
 18. Let da* be (|s.DATAS| + i_data)^(i_data<n_data).
 19. Let xi* be $instexport(fa_ex* ++ fa*, ga_ex* ++ ga*, ta_ex* ++ ta*, ma_ex* ++ ma*, export)*.
-20. Let mm be { TYPES: ft*; FUNCS: fa_ex* ++ fa*; GLOBALS: ga_ex* ++ ga*; TABLES: ta_ex* ++ ta*; MEMS: ma_ex* ++ ma*; ELEMS: ea*; DATAS: da*; EXPORTS: xi*; }.
-21. Let y_0 be $allocfuncs(mm, func^n_func).
+20. Let moduleinst be { TYPES: ft*; FUNCS: fa_ex* ++ fa*; GLOBALS: ga_ex* ++ ga*; TABLES: ta_ex* ++ ta*; MEMS: ma_ex* ++ ma*; ELEMS: ea*; DATAS: da*; EXPORTS: xi*; }.
+21. Let y_0 be $allocfuncs(moduleinst, func^n_func).
 22. Assert: Due to validation, (y_0 is fa*).
 23. Let y_0 be $allocglobals(globaltype^n_global, val*).
 24. Assert: Due to validation, (y_0 is ga*).
@@ -2762,7 +2762,7 @@ allocmodule module externval* val* ref**
 30. Assert: Due to validation, (y_0 is ea*).
 31. Let y_0 be $allocdatas(byte*^n_data).
 32. Assert: Due to validation, (y_0 is da*).
-33. Return mm.
+33. Return moduleinst.
 
 runelem (ELEM reftype expr* elemm_u0) i
 1. If (elemm_u0 is PASSIVE), then:
@@ -2795,8 +2795,8 @@ instantiate module externval*
 9. Let (ELEM reftype expr_E* elemmode)* be elem*.
 10. Let instr_D* be $concat_($rundata(data*[j], j)^(j<n_D)).
 11. Let instr_E* be $concat_($runelem(elem*[i], i)^(i<n_E)).
-12. Let mm_init be { TYPES: functype*; FUNCS: $funcs(externval*) ++ (|s.FUNCS| + i_F)^(i_F<n_F); GLOBALS: $globals(externval*); TABLES: []; MEMS: []; ELEMS: []; DATAS: []; EXPORTS: []; }.
-13. Let f_init be { LOCALS: []; MODULE: mm_init; }.
+12. Let moduleinst_init be { TYPES: functype*; FUNCS: $funcs(externval*) ++ (|s.FUNCS| + i_F)^(i_F<n_F); GLOBALS: $globals(externval*); TABLES: []; MEMS: []; ELEMS: []; DATAS: []; EXPORTS: []; }.
+13. Let f_init be { LOCALS: []; MODULE: moduleinst_init; }.
 14. Let z be f_init.
 15. Push the activation of z to the stack.
 16. Let [val]* be $eval_expr(expr_G)*.
@@ -2804,8 +2804,8 @@ instantiate module externval*
 18. Push the activation of z to the stack.
 19. Let [ref]** be $eval_expr(expr_E)**.
 20. Pop the activation of z from the stack.
-21. Let mm be $allocmodule(module, externval*, val*, ref**).
-22. Let f be { LOCALS: []; MODULE: mm; }.
+21. Let moduleinst be $allocmodule(module, externval*, val*, ref**).
+22. Let f be { LOCALS: []; MODULE: moduleinst; }.
 23. Push the activation of f with arity 0 to the stack.
 24. Execute the sequence (instr_E*).
 25. Execute the sequence (instr_D*).
@@ -2813,7 +2813,7 @@ instantiate module externval*
   a. Let ?(x_0) be x.
   b. Execute the instruction (CALL x_0).
 27. Pop the activation of f with arity 0 from the stack.
-28. Return mm.
+28. Return moduleinst.
 
 invoke fa val^n
 1. Let f be { LOCALS: []; MODULE: { TYPES: []; FUNCS: []; GLOBALS: []; TABLES: []; MEMS: []; ELEMS: []; DATAS: []; EXPORTS: []; }; }.
@@ -5693,9 +5693,9 @@ allocfuncs defty_u0* funcc_u1* modul_u2*
   b. Assert: Due to validation, (|funcc_u1*| ≥ 1).
   c. Let [funccode] ++ funccode'* be funcc_u1*.
   d. Assert: Due to validation, (|modul_u2*| ≥ 1).
-  e. Let [mm] ++ mm'* be modul_u2*.
-  f. Let fa be $allocfunc(dt, funccode, mm).
-  g. Let fa'* be $allocfuncs(dt'*, funccode'*, mm'*).
+  e. Let [moduleinst] ++ moduleinst'* be modul_u2*.
+  f. Let fa be $allocfunc(dt, funccode, moduleinst).
+  g. Let fa'* be $allocfuncs(dt'*, funccode'*, moduleinst'*).
   h. Return [fa] ++ fa'*.
 
 allocglobal globaltype val
@@ -5870,8 +5870,8 @@ instantiate module externval*
 17. Push the activation of z to the stack.
 18. Let [ref_E]** be $eval_expr(expr_E)**.
 19. Pop the activation of z from the stack.
-20. Let mm be $allocmodule(module, externval*, val_G*, ref_T*, ref_E**).
-21. Let f be { LOCALS: []; MODULE: mm; }.
+20. Let moduleinst be $allocmodule(module, externval*, val_G*, ref_T*, ref_E**).
+21. Let f be { LOCALS: []; MODULE: moduleinst; }.
 22. Push the activation of f with arity 0 to the stack.
 23. Execute the sequence (instr_E*).
 24. Execute the sequence (instr_D*).
@@ -5879,7 +5879,7 @@ instantiate module externval*
   a. Let ?(x_0) be x.
   b. Execute the instruction (CALL x_0).
 26. Pop the activation of f with arity 0 from the stack.
-27. Return mm.
+27. Return moduleinst.
 
 invoke funcaddr val*
 1. Let f be { LOCALS: []; MODULE: { TYPES: []; FUNCS: []; GLOBALS: []; TABLES: []; MEMS: []; ELEMS: []; DATAS: []; EXPORTS: []; }; }.

--- a/spectec/test-prose/TEST.md
+++ b/spectec/test-prose/TEST.md
@@ -884,7 +884,7 @@ instantiate module externval*
   a. Let ?(instr_0) be (CALL x')?.
   b. Execute the instruction instr_0.
 27. Pop the activation of f with arity 0 from the stack.
-28. Return moduleinst.
+28. Return f.MODULE.
 
 invoke fa val^n
 1. Let f be { LOCALS: []; MODULE: { TYPES: []; FUNCS: []; GLOBALS: []; TABLES: []; MEMS: []; EXPORTS: []; }; }.
@@ -2813,7 +2813,7 @@ instantiate module externval*
   a. Let ?(instr_0) be (CALL x)?.
   b. Execute the instruction instr_0.
 27. Pop the activation of f with arity 0 from the stack.
-28. Return moduleinst.
+28. Return f.MODULE.
 
 invoke fa val^n
 1. Let f be { LOCALS: []; MODULE: { TYPES: []; FUNCS: []; GLOBALS: []; TABLES: []; MEMS: []; ELEMS: []; DATAS: []; EXPORTS: []; }; }.
@@ -5880,7 +5880,7 @@ instantiate module externval*
   a. Let ?(instr_0) be instr_S?.
   b. Execute the instruction instr_0.
 27. Pop the activation of f with arity 0 from the stack.
-28. Return moduleinst.
+28. Return f.MODULE.
 
 invoke funcaddr val*
 1. Let f be { LOCALS: []; MODULE: { TYPES: []; FUNCS: []; GLOBALS: []; TABLES: []; MEMS: []; ELEMS: []; DATAS: []; EXPORTS: []; }; }.


### PR DESCRIPTION
The seemingly innocent alpha-renaming of a local variable in this PR causes a stack overflow in the interpreter:
```
File "test-interpreter/dune", line 1, characters 0-285:
 1 | (mdx
 2 |   (libraries spectec)
 3 |   (deps
....
12 |   )
13 |   (files TEST.md)
14 | )
Fatal error: exception Stack overflow
```
@f52985, @ShinWonho, could one of you please have a look?