### PR TITLE
MInor typo in numerics

### DIFF
--- a/spectec/spec/wasm-3.0/3-numerics.watsup
+++ b/spectec/spec/wasm-3.0/3-numerics.watsup
@@ -175,7 +175,7 @@ def $cvtop(Inn_1, Fnn_2, CONVERT sx, iN_1) = $convert($sizenn1(Inn_1), $sizenn2(
 def $cvtop(Fnn_1, Fnn_2, PROMOTE, fN_1) = $promote($sizenn1(Fnn_1), $sizenn2(Fnn_2), fN_1)
 def $cvtop(Fnn_1, Fnn_2, DEMOTE, fN_1) = $demote($sizenn1(Fnn_1), $sizenn2(Fnn_2), fN_1)
 def $cvtop(Inn_1, Fnn_2, REINTERPRET, iN_1) = $reinterpret(Inn_1, Fnn_2, iN_1) -- if $sizenn1(Inn_1) = $sizenn2(Fnn_2)
-def $cvtop(Fnn_1, Inn_2, REINTERPRET, fN_1) = $reinterpret(Fnn_1, Inn_2, fN_1) -- if $sizenn1(Inn_1) = $sizenn2(Fnn_2)
+def $cvtop(Fnn_1, Inn_2, REINTERPRET, fN_1) = $reinterpret(Fnn_1, Inn_2, fN_1) -- if $sizenn1(Fnn_1) = $sizenn2(Inn_2)
 
 
 ;; Packed numbers
@@ -195,7 +195,7 @@ def $cpacknum(storagetype, lit_($cunpack(storagetype))) : lit_(storagetype)
 def $cpacknum(consttype, c) = c
 def $cpacknum(packtype, c) = $wrap($size($lunpack(packtype)), $psize(packtype), c)
 
-def $cunpacknum(storagetype, lit_(storagetype)) : lit_($cunpack(storagetype)) 
+def $cunpacknum(storagetype, lit_(storagetype)) : lit_($cunpack(storagetype))
     hint(show $unpack_(%,%)) hint(macro "unpacknum")
 def $cunpacknum(consttype, c) = c
 def $cunpacknum(packtype, c) = $ext($psize(packtype), $size($lunpack(packtype)), U, c)

--- a/spectec/test-frontend/TEST.md
+++ b/spectec/test-frontend/TEST.md
@@ -2635,8 +2635,8 @@ def $cvtop(numtype_1 : numtype, numtype_2 : numtype, cvtop_ : cvtop_(numtype_1, 
   def $cvtop{Inn_1 : Inn, Fnn_2 : Fnn, iN_1 : num_((Inn_1 : Inn <: numtype))}((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), REINTERPRET_cvtop_, iN_1) = [$reinterpret((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), iN_1)]
     -- if ($sizenn1((Inn_1 : Inn <: numtype)) = $sizenn2((Fnn_2 : Fnn <: numtype)))
   ;; 3-numerics.watsup
-  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype)), Inn_1 : Inn, Fnn_2 : Fnn}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
-    -- if ($sizenn1((Inn_1 : Inn <: numtype)) = $sizenn2((Fnn_2 : Fnn <: numtype)))
+  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype))}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
+    -- if ($sizenn1((Fnn_1 : Fnn <: numtype)) = $sizenn2((Inn_2 : Inn <: numtype)))
 
 ;; 3-numerics.watsup
 def $narrow(M : M, N : N, sx : sx, iN : iN(M)) : iN(N)

--- a/spectec/test-middlend/TEST.md
+++ b/spectec/test-middlend/TEST.md
@@ -2625,8 +2625,8 @@ def $cvtop(numtype_1 : numtype, numtype_2 : numtype, cvtop_ : cvtop_(numtype_1, 
   def $cvtop{Inn_1 : Inn, Fnn_2 : Fnn, iN_1 : num_((Inn_1 : Inn <: numtype))}((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), REINTERPRET_cvtop_, iN_1) = [$reinterpret((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), iN_1)]
     -- if ($sizenn1((Inn_1 : Inn <: numtype)) = $sizenn2((Fnn_2 : Fnn <: numtype)))
   ;; 3-numerics.watsup
-  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype)), Inn_1 : Inn, Fnn_2 : Fnn}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
-    -- if ($sizenn1((Inn_1 : Inn <: numtype)) = $sizenn2((Fnn_2 : Fnn <: numtype)))
+  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype))}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
+    -- if ($sizenn1((Fnn_1 : Fnn <: numtype)) = $sizenn2((Inn_2 : Inn <: numtype)))
 
 ;; 3-numerics.watsup
 def $narrow(M : M, N : N, sx : sx, iN : iN(M)) : iN(N)
@@ -9066,8 +9066,8 @@ def $cvtop(numtype_1 : numtype, numtype_2 : numtype, cvtop_ : cvtop_(numtype_1, 
   def $cvtop{Inn_1 : Inn, Fnn_2 : Fnn, iN_1 : num_((Inn_1 : Inn <: numtype))}((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), REINTERPRET_cvtop_, iN_1) = [$reinterpret((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), iN_1)]
     -- if ($sizenn1((Inn_1 : Inn <: numtype)) = $sizenn2((Fnn_2 : Fnn <: numtype)))
   ;; 3-numerics.watsup
-  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype)), Inn_1 : Inn, Fnn_2 : Fnn}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
-    -- if ($sizenn1((Inn_1 : Inn <: numtype)) = $sizenn2((Fnn_2 : Fnn <: numtype)))
+  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype))}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
+    -- if ($sizenn1((Fnn_1 : Fnn <: numtype)) = $sizenn2((Inn_2 : Inn <: numtype)))
 
 ;; 3-numerics.watsup
 def $narrow(M : M, N : N, sx : sx, iN : iN(M)) : iN(N)
@@ -15509,8 +15509,8 @@ def $cvtop(numtype_1 : numtype, numtype_2 : numtype, cvtop_ : cvtop_(numtype_1, 
   def $cvtop{Inn_1 : Inn, Fnn_2 : Fnn, iN_1 : num_((Inn_1 : Inn <: numtype))}((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), REINTERPRET_cvtop_, iN_1) = [$reinterpret((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), iN_1)]
     -- if ($sizenn1((Inn_1 : Inn <: numtype)) = $sizenn2((Fnn_2 : Fnn <: numtype)))
   ;; 3-numerics.watsup
-  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype)), Inn_1 : Inn, Fnn_2 : Fnn}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
-    -- if ($sizenn1((Inn_1 : Inn <: numtype)) = $sizenn2((Fnn_2 : Fnn <: numtype)))
+  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype))}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
+    -- if ($sizenn1((Fnn_1 : Fnn <: numtype)) = $sizenn2((Inn_2 : Inn <: numtype)))
 
 ;; 3-numerics.watsup
 def $narrow(M : M, N : N, sx : sx, iN : iN(M)) : iN(N)
@@ -21952,8 +21952,8 @@ def $cvtop(numtype_1 : numtype, numtype_2 : numtype, cvtop_ : cvtop_(numtype_1, 
   def $cvtop{Inn_1 : Inn, Fnn_2 : Fnn, iN_1 : num_((Inn_1 : Inn <: numtype))}((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), REINTERPRET_cvtop_, iN_1) = [$reinterpret((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), iN_1)]
     -- if ($sizenn1((Inn_1 : Inn <: numtype)) = $sizenn2((Fnn_2 : Fnn <: numtype)))
   ;; 3-numerics.watsup
-  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype)), Inn_1 : Inn, Fnn_2 : Fnn}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
-    -- if ($sizenn1((Inn_1 : Inn <: numtype)) = $sizenn2((Fnn_2 : Fnn <: numtype)))
+  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype))}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
+    -- if ($sizenn1((Fnn_1 : Fnn <: numtype)) = $sizenn2((Inn_2 : Inn <: numtype)))
 
 ;; 3-numerics.watsup
 def $narrow(M : M, N : N, sx : sx, iN : iN(M)) : iN(N)
@@ -28563,8 +28563,8 @@ def $cvtop(numtype_1 : numtype, numtype_2 : numtype, cvtop_ : cvtop_(numtype_1, 
   def $cvtop{Inn_1 : Inn, Fnn_2 : Fnn, iN_1 : num_((Inn_1 : Inn <: numtype))}((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), REINTERPRET_cvtop_, iN_1) = [$reinterpret((Inn_1 : Inn <: numtype), (Fnn_2 : Fnn <: numtype), iN_1)]
     -- if ($sizenn1((Inn_1 : Inn <: numtype)) = $sizenn2((Fnn_2 : Fnn <: numtype)))
   ;; 3-numerics.watsup
-  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype)), Inn_1 : Inn, Fnn_2 : Fnn}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
-    -- where $sizenn2((Fnn_2 : Fnn <: numtype)) = $sizenn1((Inn_1 : Inn <: numtype))
+  def $cvtop{Fnn_1 : Fnn, Inn_2 : Inn, fN_1 : num_((Fnn_1 : Fnn <: numtype))}((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), REINTERPRET_cvtop_, fN_1) = [$reinterpret((Fnn_1 : Fnn <: numtype), (Inn_2 : Inn <: numtype), fN_1)]
+    -- if ($sizenn1((Fnn_1 : Fnn <: numtype)) = $sizenn2((Inn_2 : Inn <: numtype)))
 
 ;; 3-numerics.watsup
 def $narrow(M : M, N : N, sx : sx, iN : iN(M)) : iN(N)

--- a/spectec/test-prose/TEST.md
+++ b/spectec/test-prose/TEST.md
@@ -5482,7 +5482,7 @@ cvtop numty_u1 numty_u4 cvtop_u0 num__u3
 11. Assert: Due to validation, the type of numty_u4 is Inn.
 12. Let Inn_2 be numty_u4.
 13. Let fN_1 be num__u3.
-14. Assert: Due to validation, the type of $sizenn2^-1($sizenn1(Inn_1)) is Fnn.
+14. Assert: Due to validation, ($sizenn1(Fnn_1) is $sizenn2(Inn_2)).
 15. Return [$reinterpret(Fnn_1, Inn_2, fN_1)].
 
 invibytes N b*


### PR DESCRIPTION
Related to #105
There is a minor typo in `3-numerics.watsup`.

Found the error below while executing the interpreter:
```
The key 'Inn_1' is not in the map: 
{Fnn_1: F32,
  Inn_2: I32,
  cvtop_u0: REINTERPRET,
  fN_1: (POS (NAN 0x400000)),
  num__u3: (POS (NAN 0x400000)),
  numty_u1: F32,
  numty_u4: I32
}.
```