### PR TITLE
Fix deeply nested prose breaking pdflatex

### DIFF
--- a/document/core/conf.py
+++ b/document/core/conf.py
@@ -298,7 +298,18 @@ latex_elements = {
 
    # Additional stuff for the LaTeX preamble.
    # Don't type-set cross references with emphasis.
-   'preamble': '\\renewcommand\\sphinxcrossref[1]{#1}\n',
+   'preamble': r'''
+      \renewcommand\sphinxcrossref[1]{#1}
+      \usepackage{enumitem}
+      \setlistdepth{9}
+      \renewlist{enumerate}{enumerate}{9}
+      \setlist[enumerate,1]{label=\arabic*.}
+      \setlist[enumerate,2]{label=\alph*.}
+      \setlist[enumerate,3]{label=\roman*.}
+      \setlist[enumerate,4]{label=\Alph*.}
+      \setlist[enumerate,5]{label=\Roman*.}
+      \renewcommand\sphinxcrossref[1]{#1}
+   ''',
 
    # Latex figure (float) alignment
   'figure_align': 'htbp',

--- a/document/core/conf.py
+++ b/document/core/conf.py
@@ -297,6 +297,7 @@ latex_elements = {
   'pointsize': '10pt',
 
    # Additional stuff for the LaTeX preamble.
+   # enumitem package is used to allow deeper nesting of lists, than the default 4 levels.
    # Don't type-set cross references with emphasis.
    'preamble': r'''
       \renewcommand\sphinxcrossref[1]{#1}

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -707,7 +707,9 @@ $${rule: {Step_read/array.fill-*}}
 
 .. _exec-array.copy:
 
-.. todo:: (3) Introduce if-let instruction instead of "is of the case". (5) Use "the expansion of" instead of $expand function application. + Too deeply nested
+$${rule-prose: Step_read/array.copy}
+
+.. todo:: (3) Introduce if-let instruction instead of "is of the case". (5) Use "the expansion of" instead of $expand function application. + Was too deeply nested
    Below is the actual prose.
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
@@ -1906,6 +1908,8 @@ $${rule: {Step_read/return_call}}
 :math:`\RETURNCALLREF~x`
 ........................
 
+$${rule-prose: Step_read/return_call_ref}
+
 .. todo:: (*) Prose not spliced, Sphinx cannot build the document with deeply nested ordered list. (mainly caused by spurious conditions that should be assertions)
 
 1. Assert: due to :ref:`validation <valid-return_call_ref>`, a :ref:`function reference <syntax-ref>` is on the top of the stack.
@@ -1941,7 +1945,9 @@ $${rule: Step/throw}
 
 .. _exec-throw_ref:
 
-.. todo:: Too deeply nested
+$${rule-prose: Step_read/throw_ref}
+
+.. todo:: Was too deeply nested
 
 1. Assert: due to :ref:`validation <valid-throw_ref>`, a :ref:`reference <syntax-ref>` is on the top of the stack.
 


### PR DESCRIPTION
Fixes #146, this fixes the issue around deeply nested prose breaking the PDF backend.

Briefly, PDF is generated by: `spliced rST -- Sphinx --> TEX -- pdflatex --> PDF`, and previously > 5 levels of nesting of ordered lists broke pdflatex. This PR adds LaTeX `enumitem` package to the preamble of Sphinx configuration to allow more levels of prose nesting.

This is *not* the best solution to fix the problem, e.g., we may optimize the generated prose to remove redundant nestings. Yet this is a quick alternative for the time being.