### PR TITLE
Numerics

### DIFF
--- a/specification/wasm-3.0/0.2-aux.num.spectec
+++ b/specification/wasm-3.0/0.2-aux.num.spectec
@@ -6,6 +6,10 @@ def $min(nat, nat) : nat
 def $min(i, j) = i  -- if $(i <= j)
 def $min(i, j) = j  -- otherwise
 
+def $max(nat, nat) : nat
+def $max(i, j) = i  -- if $(i >= j)
+def $max(i, j) = j  -- otherwise
+
 def $sum(nat*) : nat  hint(show (+) %) hint(macro none)
 def $sum(eps) = 0
 def $sum(n n'*) = $(n + $sum(n'*))

--- a/specification/wasm-3.0/0.3-aux.seq.spectec
+++ b/specification/wasm-3.0/0.3-aux.seq.spectec
@@ -11,13 +11,61 @@ def $opt_(syntax X, w) = w
 
 ;; Concatenation
 
-def $concat_(syntax X, (X*)*) : X*  hint(show (++) %2)
+def $concat_(syntax X, (X*)*) : X*  hint(show (++) %2) hint(inverse $invconcat_)
 def $concat_(syntax X, eps) = eps
 def $concat_(syntax X, (w*) (w'*)*) = w* ++ $concat_(X, (w'*)*)
 
-def $concatn_(syntax X, (X*)*, nat) : X*  hint(show (++) %2)
+def $concatn_(syntax X, (X*)*, nat) : X*  hint(show (++) %2) hint(inverse $invconcatn_)
 def $concatn_(syntax X, eps, n) = eps
 def $concatn_(syntax X, (w^n) (w'^n)*, n) = w^n $concatn_(X, (w'^n)*, n)
+
+def $invconcat_(syntax X, X*) : (X*)*        hint(builtin "inverse_of_concat")
+def $invconcatn_(syntax X, nat, X*) : (X*)*  hint(builtin "inverse_of_concatn")
+
+
+;; List manipulation
+
+
+;; This version might be easier to define in theorem provers (eyeball close)
+def $rev_(syntax X, X*) : X*
+def $rev_(syntax X, []) = []
+def $rev_(syntax X, w_0 w*) = $rev_(X, w*) w_0
+
+;; This version is more succinct in SpecTec.
+def $rev'_(syntax X, X*) : X*
+def $rev'_(syntax X, w^N) = (w^N[N-1-i])^(i < N)
+
+def $filter_(syntax X, def $p(X) : bool, X*) : X*
+def $filter_(syntax X, $p, []) = []
+def $filter_(syntax X, $p, w_0 w*) = w_0 $filter_(X, $p, w*)  -- if $p(w_0)
+def $filter_(syntax X, $p, w_0 w*) = $filter_(X, $p, w*)  -- otherwise
+
+
+def $take_(syntax X, nat, X*) : X*
+def $take_(syntax X, 0, w*) = []
+def $take_(syntax X, n, []) = []
+def $take_(syntax X, n, w w'*) = w $take_(X, $(n-1), w'*)  -- if n > 0
+
+def $take'_(syntax X, nat, X*) : X*
+def $take'_(syntax X, n, w^n') = w^n'    -- if n' < n
+def $take'_(syntax X, n, w^n w'*) = w^n
+
+def $takeWhile_(syntax X, def $p(X) : bool, X*) : X*
+def $takeWhile_(syntax X, $p, []) = []
+def $takeWhile_(syntax X, $p, w_0 w*) = w_0 $takeWhile_(X, $p, w*)  -- if $p(w_0)
+def $takeWhile_(syntax X, $p, w_0 w*) = []                          -- otherwise
+
+
+def $drop_(syntax X, nat, X*) : X*
+def $drop_(syntax X, 0, w*) = w*
+def $drop_(syntax X, n, []) = []
+def $drop_(syntax X, n, w w'*) = $drop_(X, $(n-1), w'*)  -- if n > 0
+
+;; Doesn't work with the interpreter backend
+def $drop'_(syntax X, nat, X*) : X*
+def $drop'_(syntax X, n, w^n') = []      -- if n' < n
+def $drop'_(syntax X, n, w^n w'*) = w'*
+
 
 
 ;; Set functions

--- a/specification/wasm-3.0/1.1-syntax.values.spectec
+++ b/specification/wasm-3.0/1.1-syntax.values.spectec
@@ -22,7 +22,10 @@ syntax u64 = uN(64)
 syntax u128 = uN(128)
 syntax s33 = sN(33)
 
+var d : bit
 var b : byte
+
+syntax iLt(N) hint(show nat_(lt#%)) = 0 | ... | $nat$(N-1)
 
 
 ;; Floating-point

--- a/specification/wasm-3.0/1.1-syntax.values.spectec
+++ b/specification/wasm-3.0/1.1-syntax.values.spectec
@@ -25,8 +25,6 @@ syntax s33 = sN(33)
 var d : bit
 var b : byte
 
-syntax iLt(N) hint(show nat_(lt#%)) = 0 | ... | $nat$(N-1)
-
 
 ;; Floating-point
 

--- a/specification/wasm-3.0/1.2-syntax.types.spectec
+++ b/specification/wasm-3.0/1.2-syntax.types.spectec
@@ -203,11 +203,14 @@ def $JN(64) = I64
 
 ;; Size
 
-def $size(numtype) : nat       hint(show |%|)
+def $size(numtype) : nat       hint(show |%|) hint(inverse $invsize)
 def $vsize(vectype) : nat      hint(show |%|)
 def $psize(packtype) : nat     hint(show |%|)
-def $lsize(lanetype) : nat     hint(show |%|)
+def $lsize(lanetype) : nat     hint(show |%|) hint(inverse $invlsize)
 def $zsize(storagetype) : nat  hint(show |%|)
+
+def $invsize(nat) : numtype    hint(builtin "inverse_of_size")
+def $invlsize(nat) : lanetype  hint(builtin "inverse_of_lsize")
 
 def $size(I32) = 32
 def $size(I64) = 64
@@ -228,7 +231,7 @@ def $zsize(packtype) = $psize(packtype)
 
 
 ;; TODO(2, rossberg): get rid of these terrible hacks by defining $Inn(nat) hint(show I#%)
-def $sizenn(numtype) : nat     hint(show N)   hint(macro none)  ;; HACK!
+def $sizenn(numtype) : nat     hint(show N)   hint(macro none) hint(inverse $invsizenn)  ;; HACK!
 def $sizenn1(numtype) : nat    hint(show N_1) hint(macro none)  ;; HACK!
 def $sizenn2(numtype) : nat    hint(show N_2) hint(macro none)  ;; HACK!
 def $sizenn(nt) = $size(nt)
@@ -241,12 +244,15 @@ def $vsizenn(vt) = $vsize(vt)
 def $psizenn(packtype) : nat   hint(show N)   hint(macro none)  ;; HACK!
 def $psizenn(pt) = $psize(pt)
 
-def $lsizenn(lanetype) : nat   hint(show N)   hint(macro none)  ;; HACK!
+def $lsizenn(lanetype) : nat   hint(show N)   hint(macro none) hint(inverse $invlsizenn)  ;; HACK!
 def $lsizenn1(lanetype) : nat  hint(show N_1) hint(macro none)  ;; HACK!
 def $lsizenn2(lanetype) : nat  hint(show N_2) hint(macro none)  ;; HACK!
 def $lsizenn(lt) = $lsize(lt)
 def $lsizenn1(lt) = $lsize(lt)
 def $lsizenn2(lt) = $lsize(lt)
+
+def $invsizenn(nat) : numtype    hint(builtin "inverse_of_sizenn")
+def $invlsizenn(nat) : lanetype  hint(builtin "inverse_of_lsizenn")
 
 
 ;; Unpacking

--- a/specification/wasm-3.0/3.1-numerics.scalar.spectec
+++ b/specification/wasm-3.0/3.1-numerics.scalar.spectec
@@ -2,38 +2,95 @@
 ;; Numeric Primitives
 ;;
 
+;; Binary operators
+
+def $xor(bool, bool) : bool         hint(show %1 $xor %2)
+def $xor(bl_1, bl_2) = $(bl_1 =/= bl_2)
+
+
 ;; Conversions
 
 def $s33_to_u32(s33) : u32  hint(show %)
 
+;; This is the `trunc` function as documented in the spec.
+def $int(rat) : int                 hint(builtin "rat_to_int") hint(show $trunc(%))
+;; def $int(q) = n                     -- if n <- nat /\ $(q - 1) < n <= q
+
 
 ;; Representation
 
-def $ibits_(N, iN(N)) : bit*                         hint(show $bits_($IN(%),%))
-def $fbits_(N, fN(N)) : bit*                         hint(show $bits_($FN(%),%))
-def $ibytes_(N, iN(N)) : byte*                       hint(show $bytes_($IN(%),%))
-def $fbytes_(N, fN(N)) : byte*                       hint(show $bytes_($FN(%),%))
-def $nbytes_(numtype, num_(numtype)) : byte*         hint(show $bytes_(%,%))
-def $vbytes_(vectype, vec_(vectype)) : byte*         hint(show $bytes_(%,%))
-def $zbytes_(storagetype, lit_(storagetype)) : byte* hint(show $bytes_(%,%))
-def $cbytes_(Cnn, lit_(Cnn)) : byte*                 hint(show $bytes_(%,%))
+
+;; no padding
+def $ibits_np(nat) : bit*                            hint(show $ibits__np(%))
+def $ibits_np(n) = 0                                 -- if n = 0
+def $ibits_np(n) = 1                                 -- if n = 1
+def $ibits_np(n) = 0 $ibits_np($(n / 2))             -- if n =/= 0 /\ $(n \ 2) = 0
+def $ibits_np(n) = 1 $ibits_np($((n-1) / 2))         -- if n =/= 1 /\ $(n \ 2) = 1
 
 
-def $invibytes_(N, byte*) : iN(N) hint(show $bytes_($IN(%))^(-1)#((%)))
-def $invfbytes_(N, byte*) : fN(N) hint(show $bytes_($FN(%))^(-1)#((%)))
 
-def $invibytes_(N, b*) = n  -- if $ibytes_(N, n) = b*
-def $invfbytes_(N, b*) = p  -- if $fbytes_(N, p) = b*
+def $ibits_(N, iN(N)) : bit*                         hint(partial) hint(show $bits_($IN(%),%))  hint(inverse $invibits_)
+def $fbits_(N, fN(N)) : bit*                         hint(builtin) hint(show $bits_($FN(%),%))
+def $ibytes_(N, iN(N)) : byte*                       hint(show $bytes_($IN(%),%))               hint(inverse $invibytes_)
+def $fbytes_(N, fN(N)) : byte*                       hint(builtin) hint(show $bytes_($FN(%),%)) hint(inverse $invfbytes_)
+def $nbytes_(numtype, num_(numtype)) : byte*         hint(builtin) hint(show $bytes_(%,%))      hint(inverse $invnbytes_)
+def $vbytes_(vectype, vec_(vectype)) : byte*         hint(builtin) hint(show $bytes_(%,%))      hint(inverse $invvbytes_)
+def $zbytes_(storagetype, lit_(storagetype)) : byte* hint(builtin) hint(show $bytes_(%,%))      hint(inverse $invzbytes_)
+def $cbytes_(Cnn, lit_(Cnn)) : byte*                 hint(builtin) hint(show $bytes_(%,%))      hint(inverse $invcbytes_)
+
+
+def $invibits_(N, bit*) : iN(N)                         hint(partial) hint(show $ibits_(%)^(-1)#((%)))
+def $invibytes_(N, byte*) : iN(N)                       hint(show $bytes_($IN(%))^(-1)#((%)))
+def $invfbytes_(N, byte*) : fN(N)                       hint(show $bytes_($FN(%))^(-1)#((%))) hint(builtin "inverse_of_fbytes")
+def $invnbytes_(numtype, byte*) : num_(numtype)         hint(show $bytes_(%)^(-1)#((%)))      hint(builtin "inverse_of_nbytes")
+def $invvbytes_(vectype, byte*) : vec_(vectype)         hint(show $bytes_(%)^(-1)#((%)))      hint(builtin "inverse_of_vbytes")
+def $invzbytes_(storagetype, byte*) : lit_(storagetype) hint(show $bytes_(%)^(-1)#((%)))      hint(builtin "inverse_of_zbytes")
+def $invcbytes_(Cnn, byte*) : lit_(Cnn)                 hint(show $bytes_(%)^(-1)#((%)))      hint(builtin "inverse_of_cbytes")
+
+
+;; def $littleendian(bit*) : byte*
+;; def $littleendian(eps) = eps
+;; def $littleendian(d*) = $littleendian(d*[8:l-8]) $invibits_(8, d*[0:8])
+;;                       -- if l = |d*|
+;; FIXME(zilinc): if inline |d*|, interpreter backend runs into infinite loop.
+
+def $littleendian(bit*) : byte*                      hint(partial)
+def $littleendian(eps) = eps
+def $littleendian(d^8 d'*) = $littleendian(d'*) $invibits_(8, d^8)
+
+
+def $ibits_(N, i) = 0^(N - |d*|) d*
+                  -- if d* = $rev_(bit, $ibits_np(i))
+                  -- if |d*| <= N
+
+def $ibytes_(N, i) = $littleendian($ibits_(N, i))
+
+def $invibits_(0, eps) = 0
+def $invibits_(N, d d'*) = $(2^(N-1) * d + $invibits_($(N-1), d'*))  -- if |d'*| = $(N-1)
+;; FIXME(zilinc): The key 'N' is not in the map. e.g. i64.wast
+;; def $invibits_(N, d d'^(N-1)) = $(2^(N-1) * d + $invibits_($(N-1), d'^(N-1)))
+
+
+def $invibytes_(N, b) = b  -- if N = 8 ;; || N = 32
+def $invibytes_(N, b_0 b*) = $($invibytes_($(N-8), b*) * 2^8 + b_0)
+                           -- if $(N = |b*| * 8 + 8) /\ |b*| > 0 ;; || (N = 32 /\ |b*| <= 1)
+;; NOTE(zilinc): The interpreter implementation has that N = 32 case for packtype, but it's
+;; not in the Wasm spec. Also, would it make $invibytes a real inverse of ibytes?
+
+;; def $invibytes_(N, b*) = n  -- if $ibytes_(N, n) = b*
+;; def $invfbytes_(N, b*) = p  -- if $fbytes_(N, p) = b*
+
 
 
 ;; Signed numbers
 
-def $signed_(N, nat) : int
-def $signed_(N, i) = i           -- if $(i < 2^(N-1))
-def $signed_(N, i) = $(i - 2^N)  -- if $(2^(N-1) <= i < 2^N)
+def $signed_(N, nat) : int          hint(partial) hint(inverse $invsigned_)
+def $signed_(N, i) = i              -- if $(i < 2^(N-1))
+def $signed_(N, i) = $(i - 2^N)     -- if $(2^(N-1) <= i < 2^N)
 
-def $invsigned_(N, int) : nat    hint(show $signed_(%)^(-1)#((%)))
-def $invsigned_(N, i) = j        -- if $signed_(N, j) = i
+def $invsigned_(N, int) : nat       hint(partial) hint(show $signed_(%)^(-1)#((%)))
+def $invsigned_(N, i) = i           -- if $(0 <= i < 2^(N-1))
+def $invsigned_(N, i) = $(i + 2^N)  -- if $(-2^(N-1) <= i < 0)
 
 def $sx(storagetype) : sx?  hint(show $sx(%))
 def $sx(consttype) = eps
@@ -50,8 +107,25 @@ def $bool(bool) : nat
 def $bool(false) = 0
 def $bool(true) = 1
 
-def $int(rat) : int
-;;def $int(+-q) = +-n  -- if n <- nat /\ $(q - 1) < n <= q
+def $bit2bool(bit) : bool
+def $bit2bool(0) = false
+def $bit2bool(1) = true
+
+
+
+;; Bit-wise operators
+
+def $bitsand_(N, bit*, bit*) : bit*    hint(show %2 $AND_(%1) %3)
+def $bitsand_(N, d_1*, d_2*) = ($bool($bit2bool(d_1) /\ $bit2bool(d_2)))*
+
+def $bitsor_(N, bit*, bit*) : bit*     hint(show %2 $OR_(%1) %3)
+def $bitsor_(N, d_1*, d_2*) = ($bool($bit2bool(d_1) \/ $bit2bool(d_2)))*
+
+def $bitsxor_(N, bit*, bit*) : bit*    hint(show %2 $XOR_(%1) %3)
+def $bitsxor_(N, d_1*, d_2*) = ($bool($xor($bit2bool(d_1), $bit2bool(d_2))))*
+
+def $bitsnot_(N, bit*) : bit*          hint(show $NOT_(%1) %2)
+def $bitsnot_(N, d*) = ($bool(~ $bit2bool(d)))*
 
 
 ;; Saturation
@@ -71,7 +145,7 @@ def $sat_s_(N, i) = i               -- otherwise
 
 def $ineg_(N, iN(N)) : iN(N)
 def $iabs_(N, iN(N)) : iN(N)
-def $iclz_(N, iN(N)) : iN(N)
+def $iclz_(N, iN(N)) : iLt(N)
 def $ictz_(N, iN(N)) : iN(N)
 def $ipopcnt_(N, iN(N)) : iN(N)
 def $iextend_(N, M, sx, iN(N)) : iN(N)          hint(show $iextend_((%,%))^(%)#((%)))
@@ -85,8 +159,8 @@ def $imin_(N, sx, iN(N), iN(N)) : iN(N)         hint(show $imin_(%)^(%)%((%,%)))
 def $imax_(N, sx, iN(N), iN(N)) : iN(N)         hint(show $imax_(%)^(%)%((%,%)))
 def $iadd_sat_(N, sx, iN(N), iN(N)) : iN(N)     hint(show $iadd__sat_(%)^(%)#((%,%)))
 def $isub_sat_(N, sx, iN(N), iN(N)) : iN(N)     hint(show $isub__sat_(%)^(%)#((%,%)))
-def $iq15mulr_sat_(N, sx, iN(N), iN(N)) : iN(N) hint(show $iq15mulr__sat_(%)^(%)#((%,%)))
-def $irelaxed_q15mulr_(N, sx, iN(N), iN(N)) : iN(N)* hint(show $relaxed__iq15mulr_(%)^(%)#((%,%)))
+def $iq15mulr_sat_(N, sx, iN(N), iN(N)) : iN(N) hint(partial) hint(show $iq15mulr__sat_(%)^(%)#((%,%)))
+def $irelaxed_q15mulr_(N, sx, iN(N), iN(N)) : iN(N)* hint(show $relaxed__iq15mulr_(%)^(%)#((%,%))) hint(builtin)
 def $iavgr_(N, sx, iN(N), iN(N)) : iN(N)        hint(show $iavgr_(%)^(%)#((%,%)))
 
 def $inot_(N, iN(N)) : iN(N)
@@ -101,7 +175,7 @@ def $irotl_(N, iN(N), iN(N)) : iN(N)
 def $irotr_(N, iN(N), iN(N)) : iN(N)
 
 def $ibitselect_(N, iN(N), iN(N), iN(N)) : iN(N)
-def $irelaxed_laneselect_(N, iN(N), iN(N), iN(N)) : iN(N)*
+def $irelaxed_laneselect_(N, iN(N), iN(N), iN(N)) : iN(N)*  hint(builtin)
 
 def $ieqz_(N, iN(N)) : u32
 def $inez_(N, iN(N)) : u32
@@ -114,19 +188,36 @@ def $ile_(N, sx, iN(N), iN(N)) : u32     hint(show $ile_(%)^(%)#((%,%)))
 def $ige_(N, sx, iN(N), iN(N)) : u32     hint(show $ige_(%)^(%)#((%,%)))
 
 
-;; TODO(3, rossberg): implement numerics internally
+def $ineg_(N, i) = $((2^N - i) \ 2^N)
 
-;;def $ineg_(N, i_1) = $((2^N - i_1) \ 2^N)
-def $ineg_(N, i_1) = $invsigned_(N, $(- $signed_(N, i_1)))
+def $iabs_(N, i) = i                   -- if $signed_(N, i) >= 0
+def $iabs_(N, i) = $ineg_(N, i)        -- otherwise
 
-def $iabs_(N, i_1) = i_1             -- if $signed_(N, i_1) >= 0
-def $iabs_(N, i_1) = $ineg_(N, i_1)  -- otherwise
+;; TODO(_, zilinc)
+;; def $clzbits(bit*) : nat               hint(partial)
+;; def $clzbits(0^k) = k                  -- if k > 0 ;; -- if (d = 0)^k
+;; def $clzbits(0^k' 1 d'*) = k'          ;; -- if (d = 0)^k'
 
-;;def $iclz_(N, i_1) = k               -- if $ibits_(N, i_1) = (0)^k 1 d*
+;; def $clzbits(bit*) : nat               hint(partial)
+;; def $clzbits(d^k) = k                  -- if k > 0
+;;                                        -- if (d = 0)^k
+;; def $clzbits(d^k' 1 d'*) = k'          -- if (d = 0)^k'
 
-;;def $ictz_(N, i_1) = k               -- if $ibits_(N, i_1) = d* 1 (0)^k
+def $eqbitzero(bit) : bool             hint(show $eq__bit_0(%)) hint(show $eq__bit_0)
+def $eqbitzero(d) = ~ $bit2bool(d)
 
-;;def $ipopcnt_(N, i_1) = k            -- if $ibits_(N, i_1) = (0* 1)^k 0*
+def $eqbitone(bit): bool               hint(show $eq__bit_1(%)) hint(show $eq__bit_1)
+def $eqbitone(d) = $bit2bool(d)
+
+;; NOTE(zilinc): because `clzbits` doesn't work.
+;; def $iclz_(N, i) = $clzbits(d*)        -- if d* = $ibits_(N, i)
+def $iclz_(N, i) = |$takeWhile_(bit, $eqbitzero, d*)|   -- if d* = $ibits_(N, i)
+
+
+def $ictz_(N, i) = |$takeWhile_(bit, $eqbitzero, d'*)|  -- if d*  = $ibits_(N, i)
+                                                        -- if d'* = $rev_(bit, d*)
+
+def $ipopcnt_(N, i) = |$filter_(bit, $eqbitone, d*)|    -- if d* = $ibits_(N, i)
 
 def $iextend_(N, M, U, i) = $(i \ 2^M)
 def $iextend_(N, M, S, i) = $invsigned_(N, $signed_(M, $(i \ 2^M)))
@@ -138,33 +229,83 @@ def $isub_(N, i_1, i_2) = $((2^N + i_1 - i_2) \ 2^N)
 
 def $imul_(N, i_1, i_2) = $((i_1 * i_2) \ 2^N)
 
-;;def $idiv_(N, U, i_1, 0)   = eps
-;;def $idiv_(N, U, i_1, i_2) = $($int(i_1 / i_2))
-;;def $idiv_(N, S, i_1, 0)   = eps
-;;def $idiv_(N, S, i_1, i_2) = eps  -- if $($signed_(N, i_1) / $signed_(N, i_2)) = 2^(N-1)
-;;def $idiv_(N, S, i_1, i_2) = $($invsigned_(N, $int($signed_(N, i_1) / $signed_(N, i_2))))
+def $idiv_(N, U, i_1, 0)   = eps
+def $idiv_(N, U, i_1, i_2) = $int($(i_1 / i_2))
+def $idiv_(N, S, i_1, 0)   = eps
+def $idiv_(N, S, i_1, i_2) = eps  -- if $signed_(N, i_1) = $($signed_(N, i_2) * 2^(N-1))
+def $idiv_(N, S, i_1, i_2) = $invsigned_(N, $int($($signed_(N, i_1) / $signed_(N, i_2))))
 
-;;def $irem_(N, U, i_1, 0)   = eps
-;;def $irem_(N, U, i_1, i_2) = $(i_1 - i_2 * $int(i_1 / i_2))
-;;def $irem_(N, S, i_1, 0)   = eps
-;;def $irem_(N, S, i_1, i_2) = $($invsigned_(N, j_1 - j_2 * $int(j_1 / f_2)))
-;;                             -- if j_1 = $signed_(N, i_1) /\ j_2 = $signed_(N, i_2)
+def $irem_(N, U, i_1, 0)   = eps
+def $irem_(N, U, i_1, i_2) = $(i_1 - i_2 * $int($(i_1 / i_2)))
+def $irem_(N, S, i_1, 0)   = eps
+def $irem_(N, S, i_1, i_2) = $invsigned_(N, $(j_1 - j_2 * $int($(j_1 / j_2))))
+                             -- if j_1 = $signed_(N, i_1)
+                             -- if j_2 = $signed_(N, i_2)
 
-;;def $imin_(N, U, i_1, i_2) = i_1  -- if i_1 <= i_2
-;;def $imin_(N, U, i_1, i_2) = i_2  -- otherwise
-;;def $imin_(N, S, i_1, i_2) = i_1  -- if $signed_(N, i_1) <= $signed_(N, i_2)
-;;def $imin_(N, S, i_1, i_2) = i_2  -- otherwise
 
-;;def $imax_(N, U, i_1, i_2) = i_1  -- if i_1 >= i_2
-;;def $imax_(N, U, i_1, i_2) = i_2  -- otherwise
-;;def $imax_(N, S, i_1, i_2) = i_1  -- if $signed_(N, i_1) >= $signed_(N, i_2)
-;;def $imax_(N, S, i_1, i_2) = i_2  -- otherwise
+def $imin_(N, sx, i_1, i_2) = i_1  -- if $ilt_(N, sx, i_1, i_2) = 1
+def $imin_(N, sx, i_1, i_2) = i_2  -- otherwise
+
+def $imax_(N, sx, i_1, i_2) = i_1  -- if $igt_(N, sx, i_1, i_2) = 1
+def $imax_(N, sx, i_1, i_2) = i_2  -- otherwise
 
 def $iadd_sat_(N, U, i_1, i_2) = $sat_u_(N, $(i_1 + i_2))
 def $iadd_sat_(N, S, i_1, i_2) = $invsigned_(N, $sat_s_(N, $($signed_(N, i_1) + $signed_(N, i_2))))
 
 def $isub_sat_(N, U, i_1, i_2) = $sat_u_(N, $(i_1 - i_2))
 def $isub_sat_(N, S, i_1, i_2) = $invsigned_(N, $sat_s_(N, $($signed_(N, i_1) - $signed_(N, i_2))))
+
+;; Q15.1 multiplication: https://en.wikipedia.org/wiki/Q_(number_format)
+def $iq15mulr_sat_(N, S, i_1, i_2) = $invsigned_(N, j_2)
+                                   -- if N = 16
+                                   -- if N' = 32
+                                   -- if j_0 = $($signed_(N, i_1) * $signed_(N, i_2) + 2^14)
+                                   -- if j_1 = $ishr_(N', S, $invsigned_(N', j_0), 15)
+                                   -- if j_2 = $sat_s_(N, $signed_(N', j_1))  ;; $sat_s_ only works on signed int
+
+
+def $iavgr_(N, U, i_1, i_2) = $int($((i_1 + i_2 + 1) / 2))
+def $iavgr_(N, S, i_1, i_2) = $int($((i_1' + i_2' + 1) / 2))    -- if i_1' = $signed_(N, i_1)
+                                                                -- if i_2' = $signed_(N, i_2)
+
+def $inot_(N, i) = $invibits_(N, $bitsnot_(N, $ibits_(N, i)))
+
+def $irev_(N, i) = $invibits_(N, $rev_(bit, $ibits_(N, i)))
+
+def $iand_(N, i_1, i_2) = $invibits_(N, $bitsand_(N, $ibits_(N, i_1), $ibits_(N, i_2)))
+
+def $iandnot_(N, i_1, i_2) = $iand_(N, i_1, $inot_(N, i_2))
+
+def $ior_(N, i_1, i_2) = $invibits_(N, $bitsor_(N, $ibits_(N, i_1), $ibits_(N, i_2)))
+
+def $ixor_(N, i_1, i_2) = $invibits_(N, $bitsxor_(N, $ibits_(N, i_1), $ibits_(N, i_2)))
+
+def $ishl_(N, i_1, i_2) = $invibits_(N, d* 0^k)
+                        -- if k = $(i_2 \ N)
+                        -- if d* = $drop'_(bit, k, $ibits_(N, i_1))
+
+def $ishr_(N, U, i_1, i_2) = $invibits_(N, 0^k d*)
+                           -- if k = $(i_2 \ N)
+                           -- if d* = $take'_(bit, $(N-k), $ibits_(N, i_1))
+def $ishr_(N, S, i_1, i_2) = $invibits_(N, d_0 d_0^k d_1*)
+                           -- if k = $(i_2 \ N)
+                           -- if d_0 d_1* = $take'_(bit, $(N-k), $ibits_(N, i_1))
+
+def $irotl_(N, i_1, i_2) = $invibits_(N, d_2* d_1*)
+                         -- if k = $(i_2 \ N)
+                         -- if d_1* = $take'_(bit, k, $ibits_(N, i_1))
+                         -- if d_2* = $drop'_(bit, k, $ibits_(N, i_1))
+
+def $irotr_(N, i_1, i_2) = $invibits_(N, d_2* d_1*)
+                         -- if k = $(i_2 \ N)
+                         -- if d_1* = $take'_(bit, $(N-k), $ibits_(N, i_1))
+                         -- if d_2* = $drop'_(bit, $(N-k), $ibits_(N, i_1))
+
+;; FIXME(zilinc): type inference failure on k
+;; def $irotr_(N, i_1, i_2) = $invibits_(N, d_2^k d_1^(N-k))
+;;                          -- var k : nat
+;;                          -- if k = $(i_2 \ N) 
+;;                          -- if d_1^(N-k) d_2^k = $ibits_(N, i_1)
 
 
 def $ieqz_(N, i_1) = $bool(i_1 = 0)
@@ -189,37 +330,43 @@ def $ige_(N, U, i_1, i_2) = $bool(i_1 >= i_2)
 def $ige_(N, S, i_1, i_2) = $bool($signed_(N, i_1) >= $signed_(N, i_2))
 
 
+def $ibitselect_(N, i_1, i_2, i_3) = $ior_(N, j_1, j_2)
+                                   -- if j_1 = $iand_(N, i_1, i_3)
+                                   -- if j_3 = $inot_(N, i_3)
+                                   -- if j_2 = $iand_(N, i_2, j_3)
+
+
 ;; Floating-point operations
 
-def $fabs_(N, fN(N)) : fN(N)*
-def $fneg_(N, fN(N)) : fN(N)*
-def $fsqrt_(N, fN(N)) : fN(N)*
-def $fceil_(N, fN(N)) : fN(N)*
-def $ffloor_(N, fN(N)) : fN(N)*
-def $ftrunc_(N, fN(N)) : fN(N)*
-def $fnearest_(N, fN(N)) : fN(N)*
+def $fabs_(N, fN(N)) : fN(N)*                  hint(builtin)
+def $fneg_(N, fN(N)) : fN(N)*                  hint(builtin)
+def $fsqrt_(N, fN(N)) : fN(N)*                 hint(builtin)
+def $fceil_(N, fN(N)) : fN(N)*                 hint(builtin)
+def $ffloor_(N, fN(N)) : fN(N)*                hint(builtin)
+def $ftrunc_(N, fN(N)) : fN(N)*                hint(builtin)
+def $fnearest_(N, fN(N)) : fN(N)*              hint(builtin)
 
-def $fadd_(N, fN(N), fN(N)) : fN(N)*
-def $fsub_(N, fN(N), fN(N)) : fN(N)*
-def $fmul_(N, fN(N), fN(N)) : fN(N)*
-def $fdiv_(N, fN(N), fN(N)) : fN(N)*
-def $fmin_(N, fN(N), fN(N)) : fN(N)*
-def $fmax_(N, fN(N), fN(N)) : fN(N)*
-def $fpmin_(N, fN(N), fN(N)) : fN(N)*
-def $fpmax_(N, fN(N), fN(N)) : fN(N)*
-def $frelaxed_min_(N, fN(N), fN(N)) : fN(N)*    hint(show $frelaxed__min_(%,%,%))
-def $frelaxed_max_(N, fN(N), fN(N)) : fN(N)*    hint(show $frelaxed__max_(%,%,%))
-def $fcopysign_(N, fN(N), fN(N)) : fN(N)*
+def $fadd_(N, fN(N), fN(N)) : fN(N)*           hint(builtin)
+def $fsub_(N, fN(N), fN(N)) : fN(N)*           hint(builtin)
+def $fmul_(N, fN(N), fN(N)) : fN(N)*           hint(builtin)
+def $fdiv_(N, fN(N), fN(N)) : fN(N)*           hint(builtin)
+def $fmin_(N, fN(N), fN(N)) : fN(N)*           hint(builtin)
+def $fmax_(N, fN(N), fN(N)) : fN(N)*           hint(builtin)
+def $fpmin_(N, fN(N), fN(N)) : fN(N)*          hint(builtin)
+def $fpmax_(N, fN(N), fN(N)) : fN(N)*          hint(builtin)
+def $frelaxed_min_(N, fN(N), fN(N)) : fN(N)*   hint(builtin) hint(show $frelaxed__min_(%,%,%))
+def $frelaxed_max_(N, fN(N), fN(N)) : fN(N)*   hint(builtin) hint(show $frelaxed__max_(%,%,%))
+def $fcopysign_(N, fN(N), fN(N)) : fN(N)*      hint(builtin)
 
-def $feq_(N, fN(N), fN(N)) : u32
-def $fne_(N, fN(N), fN(N)) : u32
-def $flt_(N, fN(N), fN(N)) : u32
-def $fgt_(N, fN(N), fN(N)) : u32
-def $fle_(N, fN(N), fN(N)) : u32
-def $fge_(N, fN(N), fN(N)) : u32
+def $feq_(N, fN(N), fN(N)) : u32               hint(builtin)
+def $fne_(N, fN(N), fN(N)) : u32               hint(builtin)
+def $flt_(N, fN(N), fN(N)) : u32               hint(builtin)
+def $fgt_(N, fN(N), fN(N)) : u32               hint(builtin)
+def $fle_(N, fN(N), fN(N)) : u32               hint(builtin)
+def $fge_(N, fN(N), fN(N)) : u32               hint(builtin)
 
-def $frelaxed_madd_(N, fN(N), fN(N), fN(N)) : fN(N)*    hint(show $frelaxed__madd_(%,%,%))
-def $frelaxed_nmadd_(N, fN(N), fN(N), fN(N)) : fN(N)*   hint(show $frelaxed__nmadd_(%,%,%))
+def $frelaxed_madd_(N, fN(N), fN(N), fN(N)) : fN(N)*   hint(builtin) hint(show $frelaxed__madd_(%,%,%))
+def $frelaxed_nmadd_(N, fN(N), fN(N), fN(N)) : fN(N)*  hint(builtin) hint(show $frelaxed__nmadd_(%,%,%))
 
 
 ;; TODO(3, rossberg): implement numerics internally
@@ -229,18 +376,26 @@ def $frelaxed_nmadd_(N, fN(N), fN(N), fN(N)) : fN(N)*   hint(show $frelaxed__nma
 
 def $wrap__(M, N, iN(M)) : iN(N)
 def $extend__(M, N, sx, iN(M)) : iN(N)               hint(show $extend_((%,%))^(%)#((%)))
-def $trunc__(M, N, sx, fN(M)) : iN(N)?               hint(show $trunc_((%,%))^(%)#((%)))
-def $trunc_sat__(M, N, sx, fN(M)) : iN(N)?           hint(show $trunc__sat_((%,%))^(%)#((%)))
-def $relaxed_trunc__(M, N, sx, fN(M)) : iN(N)?       hint(show $relaxed__trunc_((%,%))^(%)#((%)))
-def $demote__(M, N, fN(M)) : fN(N)*
-def $promote__(M, N, fN(M)) : fN(N)*
-def $convert__(M, N, sx, iN(M)) : fN(N)              hint(show $convert_((%,%))^(%)#((%)))
+def $trunc__(M, N, sx, fN(M)) : iN(N)?               hint(builtin) hint(show $trunc_((%,%))^(%)#((%)))
+def $trunc_sat__(M, N, sx, fN(M)) : iN(N)?           hint(builtin) hint(show $trunc__sat_((%,%))^(%)#((%)))
+def $relaxed_trunc__(M, N, sx, fN(M)) : iN(N)?       hint(builtin) hint(show $relaxed__trunc_((%,%))^(%)#((%)))
+def $demote__(M, N, fN(M)) : fN(N)*                  hint(builtin)
+def $promote__(M, N, fN(M)) : fN(N)*                 hint(builtin)
+def $convert__(M, N, sx, iN(M)) : fN(N)              hint(builtin) hint(show $convert_((%,%))^(%)#((%)))
 def $narrow__(M, N, sx, iN(M)) : iN(N)               hint(show $narrow_((%,%))^(%)#(%))
 
-def $reinterpret__(numtype_1, numtype_2, num_(numtype_1)) : num_(numtype_2)
+def $reinterpret__(numtype_1, numtype_2, num_(numtype_1)) : num_(numtype_2)  hint(builtin)
 
 
 ;; TODO(3, rossberg): implement numerics internally
+
+def $wrap__(M, N, i) = $(i \ 2^N)
+
+def $extend__(M, N, U, i) = i
+def $extend__(M, N, S, i) = $invsigned_(N, $signed_(M, i))
+
+def $narrow__(M, N, U, i) = $sat_u_(N, $signed_(M, i))
+def $narrow__(M, N, S, i) = $invsigned_(N, $sat_s_(N, $signed_(M, i)))
 
 
 ;; Packed numbers
@@ -274,11 +429,11 @@ def $cunpacknum_(packtype, c) = $extend__($psize(packtype), $size($lunpack(packt
 def $unop_(numtype, unop_(numtype), num_(numtype)) : num_(numtype)*
     hint(show %2#$_(%1,%3))
 def $binop_(numtype, binop_(numtype), num_(numtype), num_(numtype)) : num_(numtype)*
-    hint(show %2#$_(%1,%3, %4))
+    hint(show %2#$_(%1,%3,%4))
 def $testop_(numtype, testop_(numtype), num_(numtype)) : u32
     hint(show %2#$_(%1,%3))
 def $relop_(numtype, relop_(numtype), num_(numtype), num_(numtype)) : u32
-    hint(show %2#$_(%1,%3, %4))
+    hint(show %2#$_(%1,%3,%4))
 def $cvtop__(numtype_1, numtype_2, cvtop__(numtype_1, numtype_2), num_(numtype_1)) : num_(numtype_2)*
     hint(show %3#$__(%1,%2,%4))
 

--- a/specification/wasm-3.0/3.1-numerics.scalar.spectec
+++ b/specification/wasm-3.0/3.1-numerics.scalar.spectec
@@ -145,7 +145,7 @@ def $sat_s_(N, i) = i               -- otherwise
 
 def $ineg_(N, iN(N)) : iN(N)
 def $iabs_(N, iN(N)) : iN(N)
-def $iclz_(N, iN(N)) : iLt(N)
+def $iclz_(N, iN(N)) : iN(N)
 def $ictz_(N, iN(N)) : iN(N)
 def $ipopcnt_(N, iN(N)) : iN(N)
 def $iextend_(N, M, sx, iN(N)) : iN(N)          hint(show $iextend_((%,%))^(%)#((%)))

--- a/specification/wasm-3.0/3.2-numerics.vector.spectec
+++ b/specification/wasm-3.0/3.2-numerics.vector.spectec
@@ -7,11 +7,11 @@
 
 ;; Lanes
 
-def $lanes_(shape, vec_(V128)) : lane_($lanetype(shape))*
+def $lanes_(shape, vec_(V128)) : lane_($lanetype(shape))*    hint(inverse $invlanes_) hint(builtin)
 
 def $invlanes_(shape, lane_($lanetype(shape))*) : vec_(V128)
-    hint(show $lanes_(%)^(-1)#((%)))
-def $invlanes_(sh, c*) = vc  -- if c* = $lanes_(sh, vc)
+    hint(show $lanes_(%)^(-1)#((%))) hint(builtin "inverse_of_lanes")
+;; def $invlanes_(sh, c*) = vc  -- if c* = $lanes_(sh, vc)
 
 def $zeroop(shape_1, shape_2, vcvtop__(shape_1, shape_2)) : zero?
 def $zeroop(Jnn_1 X M_1, Jnn_2 X M_2, EXTEND half sx) = eps

--- a/spectec/doc/Language.md
+++ b/spectec/doc/Language.md
@@ -182,7 +182,7 @@ In a first approximation,
 an atom is either an uppercase identifier,
 or one of various recognised *symbolic* atoms,
 such as `|-`, `:`, or `->`,
-or pairs of maching brackets escaped with `` ` ``.
+or pairs of matching brackets escaped with `` ` ``.
 Some symbolic atoms have infix operator status
 (with hard-coded "natural" precedences),
 affecting the way they are parsed;

--- a/spectec/doc/Latex.md
+++ b/spectec/doc/Latex.md
@@ -63,7 +63,7 @@ SpecTec interprets underscores as subscripting in a few places:
 
 * In a function identifier,
   trailing underscores cause the leading arguments to be set as a subscript,
-  specifcally, as many arguments as trailing underscores
+  specifically, as many arguments as trailing underscores
   (e.g., `$f_(i, x, y)` becomes `f_i(x, y)` in Latex,
   while `$f__(i, j, x)` becomes `f_{i, j}(x)`).
 
@@ -227,6 +227,11 @@ Hints of the form `hint(show <exp>)` are recognised on a number of constructs an
   while, the operator `#` represents textual concatenation;
   see below for details.
 
+* When a function identifier shall be displayed with both a subscript and a superscript,
+  as SpecTec has built-in support for subscripts as described above, the underscore(s) (`_`)
+  for subscripts should come first, followed by the superscript (e.g. `^(-1)` for the inverse
+  function). E.g. `$signed_(%)^(-1)#((%))`.
+
 * For a variant case or a function declaration,
   show hints control how the case is rendered;
   the expression will typically contain holes `%`,
@@ -296,7 +301,7 @@ Show hints for variant cases or function definition are expressions with two add
 
 * *Literal Latex* `%latex("text")` inserts the text as Latex source code unmodified.
   **Use with care!**
-  This is considered a last resort that shoul dbe avoided if possible,
+  This is considered a last resort that should be avoided if possible,
   since it may not work with future rendering backends.
 
 **Example:**
@@ -381,8 +386,8 @@ The default macro names can be overridden by macro hints.
 * `hint(macro none)` selectively suppresses macro generation for an individual identifier,
   and is likewise recognised for all definitions that bind identifiers.
 
-* `hint(macro "text1" "text2")` is avaliable for type definitions,
-  and choses alternative macro names for both the type identifier (`text1`)
+* `hint(macro "text1" "text2")` is available for type definitions,
+  and chooses alternative macro names for both the type identifier (`text1`)
   and for all atoms in its definition (`text2`).
   The latter typically uses `%` to adapt to each case.
 
@@ -405,7 +410,7 @@ syntax comptype =
 ```
 
 Macro hints also apply to symbolic operator atoms.
-This way, such operators can alo be customised,
+This way, such operators can also be customised,
 for example, to produce cross-references.
 
 **Example:**

--- a/spectec/doc/Latex.md
+++ b/spectec/doc/Latex.md
@@ -227,11 +227,6 @@ Hints of the form `hint(show <exp>)` are recognised on a number of constructs an
   while, the operator `#` represents textual concatenation;
   see below for details.
 
-* When a function identifier shall be displayed with both a subscript and a superscript,
-  as SpecTec has built-in support for subscripts as described above, the underscore(s) (`_`)
-  for subscripts should come first, followed by the superscript (e.g. `^(-1)` for the inverse
-  function). E.g. `$signed_(%)^(-1)#((%))`.
-
 * For a variant case or a function declaration,
   show hints control how the case is rendered;
   the expression will typically contain holes `%`,
@@ -312,6 +307,16 @@ syntax instr = ...
   | EXTEND numtype n   hint(show %.EXTEND#%)
 ```
 With those, the expressions `CONST f64 5` and `EXTEND i32 8` will be rendered as `f64.const 5` and `i32.extend8`, respectively.
+
+**Example:**
+Super- and subscripts can be combined in a show hint:
+```
+def $f(nat, nat, nat, nat) : nat  hint(show $f_(%)^(%)#((%,%))
+```
+Here, the underscore in the function name turns the immediate argument into a subscript,
+while the superscript is explicit.
+The remaining argument(s) are concatenated as a tuple.
+
 
 
 #### Macro Hints (`macro`)

--- a/spectec/src/al/al_util.ml
+++ b/spectec/src/al/al_util.ml
@@ -44,6 +44,7 @@ let mk_expr at note it = it $$ at % note
 
 let varE ?(at = no) ~note id = VarE id |> mk_expr at note
 let boolE ?(at = no) ~note b = BoolE b |> mk_expr at note
+let textE ?(at = no) ~note s = TextE s |> mk_expr at note
 let numE ?(at = no) ~note i = NumE i |> mk_expr at note
 let natE ?(at = no) ~note i = NumE (`Nat i) |> mk_expr at note
 let cvtE ?(at = no) ~note (e, nt1, nt2) = CvtE (e, nt1, nt2) |> mk_expr at note
@@ -94,6 +95,7 @@ let natV i = assert (i >= Z.zero); NumV (`Nat i)
 let intV i = NumV (`Int i)
 let natV_of_int i = Z.of_int i |> natV
 let boolV b = BoolV b
+let textV s = TextV s
 let strV r = StrV r
 let caseV (s, vl) = CaseV (s, vl)
 let optV v_opt = OptV v_opt

--- a/spectec/src/al/ast.ml
+++ b/spectec/src/al/ast.ml
@@ -64,6 +64,7 @@ and expr' =
   | VarE of id                                    (* varid *)
   | NumE of Num.num                               (* number *)
   | BoolE of bool                                 (* boolean *)
+  | TextE of string                               (* text *)
   | CvtE of expr * numtyp * numtyp                (* conversion *)
   | UnE of unop * expr                            (* unop expr *)
   | BinE of binop * expr * expr                   (* expr binop expr *)

--- a/spectec/src/al/free.ml
+++ b/spectec/src/al/free.ml
@@ -18,6 +18,7 @@ let rec free_expr expr =
   match expr.it with
   | NumE _
   | BoolE _
+  | TextE _
   | GetCurStateE
   | GetCurContextE _
   | ContextKindE _

--- a/spectec/src/al/print.ml
+++ b/spectec/src/al/print.ml
@@ -112,6 +112,7 @@ and string_of_expr expr =
   match expr.it with
   | NumE n -> Num.to_string n
   | BoolE b -> string_of_bool b
+  | TextE s -> s
   | CvtE (e, _, t) -> sprintf "$%s$(%s)" (Il.Print.string_of_numtyp t) (string_of_expr e)
   | UnE (op, e) -> sprintf "%s(%s)" (string_of_unop op) (string_of_expr e)
   | BinE (op, e1, e2) ->
@@ -395,7 +396,7 @@ and structured_string_of_record_expr r =
 
 and structured_string_of_expr expr =
   match expr.it with
-  | NumE _ | BoolE _ -> string_of_expr expr
+  | NumE _ | BoolE _ | TextE _ -> string_of_expr expr
   | CvtE (e, t1, t2) ->
     "CvtE ("
     ^ structured_string_of_expr e

--- a/spectec/src/al/valid.ml
+++ b/spectec/src/al/valid.ml
@@ -250,6 +250,12 @@ let check_bool source typ =
   | BoolT -> ()
   | _ -> error_mismatch source typ (varT "bool")
 
+
+let check_text source typ =
+  match (get_base_typ typ).it with
+  | TextT -> ()
+  | _ -> error_mismatch source typ (varT "text")
+
 let check_list source typ =
   match typ.it with
   | IterT (_, iter) when iter <> Opt -> ()
@@ -474,6 +480,7 @@ and valid_expr env (expr: expr) : unit =
   | VarE id ->
     if not (Env.mem id env) then error expr.at ("free identifier " ^ id)
   | NumE _ -> check_num source expr.note;
+  | TextE _ -> check_text source expr.note;
   | BoolE _  | IsCaseOfE _ | IsValidE _ | MatchE _ | HasTypeE _ | ContextKindE _ ->
     check_bool source expr.note;
   | CvtE (expr', _, _) ->

--- a/spectec/src/al/walk.ml
+++ b/spectec/src/al/walk.ml
@@ -33,7 +33,7 @@ let walk_path (walker: unit_walker) (path: path) : unit =
 
 let walk_expr (walker: unit_walker) (expr: expr) : unit =
   match expr.it with
-  | VarE _ | SubE _ | NumE _ | BoolE _ | GetCurStateE
+  | VarE _ | SubE _ | NumE _ | BoolE _ | TextE _ | GetCurStateE
   | GetCurContextE _ | YetE _
   | TopValueE None | ContextKindE _ -> ()
 
@@ -130,7 +130,7 @@ let walk_expr (walker: walker) (expr: expr) : expr =
   let walk_expr = walker.walk_expr walker in
   let it =
     match expr.it with
-    | NumE _ | BoolE _ | VarE _ | SubE _ | GetCurStateE
+    | NumE _ | BoolE _ | TextE _ | VarE _ | SubE _ | GetCurStateE
     | GetCurContextE _ | ContextKindE _ | YetE _ -> expr.it
     | CvtE (e, t1, t2) -> CvtE (walk_expr e, t1, t2)
     | UnE (op, e) -> UnE (op, walk_expr e)

--- a/spectec/src/backend-interpreter/interpreter.ml
+++ b/spectec/src/backend-interpreter/interpreter.ml
@@ -203,6 +203,7 @@ and eval_expr env expr =
   (* Value *)
   | NumE n -> numV n
   | BoolE b -> boolV b
+  | TextE s -> textV s
   (* Numeric Operation *)
   | CvtE (e1, _, nt) ->
     (match eval_expr env e1 with

--- a/spectec/src/backend-interpreter/interpreter.ml
+++ b/spectec/src/backend-interpreter/interpreter.ml
@@ -418,6 +418,12 @@ and has_same_keys re rv =
 
 and assign lhs rhs env =
   match lhs.it, rhs with
+  | _ when Free.IdSet.is_empty (Free.free_expr lhs) ->
+    (* when the lhs is a constant *)
+    let lhs' = eval_expr Ds.Env.empty lhs in
+    if lhs' = rhs then env
+    else
+      fail_expr lhs ("invalid assignment: constant lhs not equal to rhs " ^ string_of_value rhs)
   | VarE name, _ -> Env.add name rhs env
   | IterE ({ it = VarE x1; _ }, ((List|List1), [x2, lhs'])), ListV _ when x1 = x2 ->
     assign lhs' rhs env
@@ -495,6 +501,7 @@ and assign_split lhs vs env =
     let get_fixed_length e =
       match e.it with
       | ListE es -> Some (List.length es)
+      (* FIXME(zilinc): If e contains fresh vars, then it will fail to eval. *)
       | IterE (_, (ListN (e, None), _)) -> Some (al_to_nat (eval_expr env e))
       | _ -> None
     in

--- a/spectec/src/backend-interpreter/numerics.ml
+++ b/spectec/src/backend-interpreter/numerics.ml
@@ -78,6 +78,17 @@ let r_swizzle = relaxed "R_swizzle" 0
 let r_laneselect = relaxed "R_laneselect" 0
 
 
+let rat_to_int : numerics =
+  {
+    name = "rat_to_int";
+    f =
+      (function
+      | [ NumV (`Rat q) ] ->
+        Q.to_bigint q |> al_of_z_int
+      | vs -> error_values "rat_to_int" vs
+      )
+  }
+
 let signed : numerics =
   {
     name = "signed";

--- a/spectec/src/backend-prose/print.ml
+++ b/spectec/src/backend-prose/print.ml
@@ -75,6 +75,7 @@ and string_of_expr expr =
   match expr.it with
   | NumE n -> Num.to_string n
   | BoolE b -> string_of_bool b
+  | TextE s -> s
   | CvtE (e, _, _) -> string_of_expr e  (* TODO: show? *)
   | UnE (`NotOp, { it = IsCaseOfE (e, a); _ }) ->
     sprintf "%s is not %s" (string_of_expr e) (string_of_atom a)

--- a/spectec/src/il2al/translate.ml
+++ b/spectec/src/il2al/translate.ml
@@ -164,6 +164,7 @@ and translate_exp exp =
   match exp.it with
   | Il.NumE n -> numE n ~at ~note
   | Il.BoolE b -> boolE b ~at ~note
+  | Il.TextE s -> textE s ~at ~note
   (* List *)
   | Il.LenE inner_exp -> lenE (translate_exp inner_exp) ~at ~note
   | Il.ListE exps -> listE (List.map translate_exp exps) ~at ~note

--- a/spectec/test-prose/doc/exec/numerics-in.rst
+++ b/spectec/test-prose/doc/exec/numerics-in.rst
@@ -5,6 +5,141 @@ Numerics
 
 .. _exec-numerics-sign-interpretation:
 
+
+Utils
+~~~~~
+
+.. _def-xor:
+
+$${definition: xor}
+
+.. _def_bitsand_:
+
+$${definition: bitsand_}
+
+.. _def_bitsor_:
+
+$${definition: bitsor_}
+
+.. _def_bitsxor_:
+
+$${definition-prose: bitsxor_}
+
+\
+
+$${definition: bitsxor_}
+
+.. _def_bitsnot_:
+
+$${definition: bitsnot_}
+
+
+
+.. _def-rev_:
+.. _def_rev'_:
+
+
+$${definition-prose: rev_}
+
+\
+
+$${definition: rev_}
+
+\
+
+$${definition-prose: rev'_}
+
+\
+
+$${definition: rev'_}
+
+.. _def_filter_:
+
+$${definition-prose: filter_}
+
+\
+
+$${definition: filter_}
+
+
+.. _def_take_:
+.. _def_take'_:
+
+$${definition: take_}
+
+\
+
+$${definition: take'_}
+
+
+.. _def_takeWhile_:
+
+$${definition-prose: takeWhile_}
+
+\
+
+$${definition: takeWhile_}
+
+
+.. _def_drop_:
+.. _def_drop'_:
+
+$${definition: drop_}
+
+\
+
+$${definition: drop'_}
+
+
+
+Binary Representation
+~~~~~~~~~~~~~~~~~~~~~
+
+.. _def-ibits_np:
+
+$${definition-prose: ibits_np}
+
+\
+
+$${definition: ibits_np}
+
+
+.. _def-ibits_:
+
+$${definition-prose: ibits_}
+
+\
+
+$${definition: ibits_}
+
+\
+
+$${definition-prose: invibits_}
+
+\
+
+$${definition: invibits_}
+
+
+.. _def-littleendian:
+
+$${definition-prose: littleendian}
+
+\
+
+$${definition: littleendian}
+
+
+.. _def-ibytes_:
+
+$${definition-prose: ibytes_}
+
+\
+
+$${definition: ibytes_}
+
+
+
 Sign Interpretation
 ~~~~~~~~~~~~~~~~~~~
 
@@ -23,3 +158,154 @@ $${definition-prose: invsigned_}
 \
 
 $${definition: invsigned_}
+
+
+
+Integer Operations
+~~~~~~~~~~~~~~~~~~
+
+.. _def-iadd_:
+.. _def-isub_:
+.. _def-imul_:
+.. _def-idiv_:
+.. _def-irem_:
+
+$${definition: iadd_}
+
+$${definition: isub_}
+
+$${definition: imul_}
+
+$${definition: idiv_}
+
+$${definition: irem_}
+
+
+.. _def-ilt_:
+.. _def-igt_:
+
+$${definition: ilt_}
+
+$${definition: igt_}
+
+.. _def-imin_:
+.. _def-imax_:
+
+
+$${definition: imin_}
+
+$${definition: imax_}
+
+
+.. _def_iq15mulr_sat_:
+
+$${definition-prose: iq15mulr_sat_}
+
+\
+
+$${definition: iq15mulr_sat_}
+
+.. _def-iclz_:
+.. _def-ictz_:
+
+$${definition: eqbitzero}
+
+$${definition: eqbitone}
+
+
+\
+
+$${definition-prose: iclz_}
+
+\
+
+$${definition: iclz_}
+
+\
+
+$${definition-prose: ictz_}
+
+\
+
+$${definition: ictz_}
+
+\
+
+$${definition-prose: ipopcnt_}
+
+\
+
+$${definition: ipopcnt_}
+
+
+
+`inot_`, `irev_`, `iand_`, `iandnot_`, `ior_` and `ixor_`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _def-inot_:
+.. _def-irev_:
+.. _def-iand_:
+.. _def-iandnot_:
+.. _def-ior_:
+.. _def-ixor_:
+
+
+$${definition: inot_}
+
+$${definition: irev_}
+
+$${definition: iand_}
+
+$${definition: iandnot_}
+
+$${definition: ior_}
+
+$${definition: ixor_}
+
+.. _def_ishl_:
+.. _def_ishr_:
+.. _def_irotl_:
+.. _def_irotr_:
+
+
+$${definition-prose: ishl_}
+
+\
+
+$${definition: ishl_}
+
+\
+
+$${definition-prose: ishr_}
+
+\
+
+$${definition: ishr_}
+
+\
+
+$${definition-prose: irotl_}
+
+\
+
+$${definition: irotl_}
+
+\
+
+$${definition-prose: irotr_}
+
+\
+
+$${definition: irotr_}
+
+
+.. _def-ibitselect_:
+
+$${definition-prose: ibitselect_}
+
+\
+
+$${definition: ibitselect_}
+
+
+


### PR DESCRIPTION
This PR includes the following changes:

1. Add a missing case in the handling of assignments in the interpreter backend, where the LHS is a constant.
2. Allow texts in the term language in SpecTec compiler.
3. Add `inverse` and `builtin` hints to spectec that are used by the interpreter backend.
4. Implement all the integer numeric functions as spectec functions, in lieu of their hardcoded definitions in the interpreter.
5. Add several generic auxiliary functions (mostly on sequences) for the numeric operations.
6. Add prose gen tests.

I leave several types of things as comments in the spectec files, instead of removing them, primarily in section 3.1. They are:
1. Failed attempts of some function definitions, due to currently limitations in the implementation.
2. The original definition of inverse functions (those that calls the inverse in the if side condition), because they state the mathematical relation with its inverse, in particular which argument becomes the output, and this is not reflected with the hint.
3. Other misc things that are noteworthy.