### PR TITLE
Wasm 2.0 spec fixes - non-exhaustive pattern matching

### DIFF
--- a/specification/wasm-2.0/0-aux.spectec
+++ b/specification/wasm-2.0/0-aux.spectec
@@ -29,10 +29,9 @@ def $sum(n n'*) = $(n + $sum(n'*))
 
 ;; General sequence functions
 
-def $opt_(syntax X, X*) : X?  hint(show %2)
+def $opt_(syntax X, X*) : X?  hint(show %2) hint(partial)
 def $opt_(syntax X, eps) = eps
 def $opt_(syntax X, w) = w
-def $opt_(syntax X, w w'*) = w
 
 def $list_(syntax X, X?) : X*  hint(show %2)
 def $list_(syntax X, eps) = eps

--- a/specification/wasm-2.0/0-aux.spectec
+++ b/specification/wasm-2.0/0-aux.spectec
@@ -32,6 +32,7 @@ def $sum(n n'*) = $(n + $sum(n'*))
 def $opt_(syntax X, X*) : X?  hint(show %2)
 def $opt_(syntax X, eps) = eps
 def $opt_(syntax X, w) = w
+def $opt_(syntax X, w w'*) = w
 
 def $list_(syntax X, X?) : X*  hint(show %2)
 def $list_(syntax X, eps) = eps

--- a/specification/wasm-2.0/1-syntax.spectec
+++ b/specification/wasm-2.0/1-syntax.spectec
@@ -35,11 +35,11 @@ var b : byte
 
 ;; Floating-point
 
-def $signif(N) : nat
+def $signif(N) : nat hint(partial)
 def $signif(32) = 23
 def $signif(64) = 52
 
-def $expon(N) : nat
+def $expon(N) : nat hint(partial)
 def $expon(32) = 8
 def $expon(64) = 11
 
@@ -203,7 +203,7 @@ var xt : externtype
 
 def $lanetype(shape) : lanetype
 
-def $size(valtype) : nat      hint(show |%|)
+def $size(valtype) : nat      hint(show |%|) hint(partial)
 def $psize(packtype) : nat    hint(show |%|)
 def $lsize(lanetype) : nat    hint(show |%|)
 def $isize(Inn) : nat         hint(show |%|) hint(inverse $inv_isize)
@@ -214,6 +214,7 @@ def $size(I32) = 32
 def $size(I64) = 64
 def $size(F32) = 32
 def $size(F64) = 64
+def $size(V128) = 128
 
 def $psize(I8) = 8
 def $psize(I16) = 16
@@ -240,7 +241,7 @@ def $lsizenn1(lt) = $lsize(lt)
 def $lsizenn2(lt) = $lsize(lt)
 
 def $inv_isize(nat) : Inn hint(partial)
-def $inv_jsize(nat) : Jnn hint(partial)
+def $inv_jsize(nat) : Jnn
 def $inv_fsize(nat) : Fnn hint(partial)
 
 def $inv_isize(32) = I32

--- a/specification/wasm-2.0/1-syntax.spectec
+++ b/specification/wasm-2.0/1-syntax.spectec
@@ -241,7 +241,7 @@ def $lsizenn1(lt) = $lsize(lt)
 def $lsizenn2(lt) = $lsize(lt)
 
 def $inv_isize(nat) : Inn hint(partial)
-def $inv_jsize(nat) : Jnn
+def $inv_jsize(nat) : Jnn hint(partial)
 def $inv_fsize(nat) : Fnn hint(partial)
 
 def $inv_isize(32) = I32
@@ -250,7 +250,8 @@ def $inv_fsize(32) = F32
 def $inv_fsize(64) = F64
 def $inv_jsize(8)  = I8
 def $inv_jsize(16) = I16
-def $inv_jsize(n)  = $inv_isize(n)
+def $inv_jsize(32) = I32 ;; HACK! should use $inv_isize
+def $inv_jsize(64) = I64 ;; HACK! should use $inv_isize
 
 
 syntax num_(numtype)

--- a/specification/wasm-2.0/2-syntax-aux.spectec
+++ b/specification/wasm-2.0/2-syntax-aux.spectec
@@ -21,19 +21,6 @@ def $concat_bytes((b*) (b'*)*) = b* $concat_bytes((b'*)*)
 ;;def $psize(packtype) : nat    hint(show |%|)
 ;;def $lsize(lanetype) : nat    hint(show |%|)
 
-def $size(I32) = 32
-def $size(I64) = 64
-def $size(F32) = 32
-def $size(F64) = 64
-def $size(V128) = 128
-
-def $isize(Inn) = $size(Inn)
-
-def $psize(I8) = 8
-def $psize(I16) = 16
-
-def $lsize(numtype) = $size(numtype)
-def $lsize(packtype) = $psize(packtype)
 
 
 ;; Unpacking


### PR DESCRIPTION
This PR has the following changes to the Webassembly 2.0 spec:
1. For the function `$opt_`, a new clause is added to cover the cases where the list has more the a single element
2. `$signif` `$expon` and `$size` must have the hint "partial" since they don't cover the entire domain.
3. `$inv_jsize` does not need the hint "partial" since its last clause covers all numbers
4. duplication of function clauses in `2-syntax-aux.spectec`
These are all problems that are found when translating the spec down to rocq, which requires functions to have exhaustive pattern matching.