### PR TITLE
[spec] Backporting soundness spec to Wasm 1.0 and 2.0

### DIFF
--- a/specification/wasm-1.0/0-aux.spectec
+++ b/specification/wasm-1.0/0-aux.spectec
@@ -40,3 +40,7 @@ def $list_(syntax X, w) = w
 def $concat_(syntax X, (X*)*) : X*  hint(show $concat(%2))
 def $concat_(syntax X, eps) = eps
 def $concat_(syntax X, (w*) (w'*)*) = w* $concat_(X, (w'*)*)
+
+def $disjoint_(syntax X, X*) : bool  hint(show %2 $disjoint) hint(macro none)
+def $disjoint_(syntax X, eps) = true
+def $disjoint_(syntax X, w w'*) = ~(w <- w'*) /\ $disjoint_(X, w'*)

--- a/specification/wasm-1.0/B-soundness.spectec
+++ b/specification/wasm-1.0/B-soundness.spectec
@@ -112,9 +112,10 @@ rule Meminst_ok:
   -- if |b*| = $(n * $($(64 * $Ki)))
 
 rule Tableinst_ok:
-  s |- {TYPE `[n..m] , REFS ref*} : `[n..m]
+  s |- {TYPE `[n..m] , REFS (fa?)*} : `[n..m]
   -- Tabletype_ok: |- `[n..m] : OK
-  -- if |ref*| = n
+  -- ((Externaddr_ok: s |- FUNC fa : FUNC ft)?)*
+  -- if |(fa?)*| = n
 
 rule Funcinst_ok:
   s |- {TYPE ft, MODULE moduleinst, CODE func} : ft

--- a/specification/wasm-1.0/B-soundness.spectec
+++ b/specification/wasm-1.0/B-soundness.spectec
@@ -230,7 +230,7 @@ relation State_ok: |- state : context
 relation Config_ok: |- config : resulttype
 
 rule Frame_ok:
-  s |- {LOCALS val*, MODULE moduleinst} : C ++ {LOCALS lct*}
+  s |- {LOCALS val*, MODULE moduleinst} : C ++ {LOCALS t*}
   -- Moduleinst_ok: s |- moduleinst : C
   -- (Val_ok: |- val : t)*
 

--- a/specification/wasm-1.0/B-soundness.spectec
+++ b/specification/wasm-1.0/B-soundness.spectec
@@ -1,3 +1,25 @@
+;; Contexts
+
+relation Context_ok: |- context : OK  hint(macro "%context")
+
+rule Context_ok:
+  |- C : OK
+  -- if C =
+    { TYPES ft*,
+      FUNCS ft_2*,
+      GLOBALS gt*,
+      MEMS mt*,
+      TABLES tt*,
+      LOCALS lct*,
+      LABELS rt*,
+      RETURN rt'?,
+    }
+  -- (Functype_ok: |- ft : OK)*
+  -- (Globaltype_ok: |- gt : OK)*
+  -- (Memtype_ok: |- mt : OK)*
+  -- (Tabletype_ok: |- tt : OK)*
+  -- (Functype_ok: |- ft_2 : OK)*
+  
 ;; Value type ok
 
 relation Val_ok: |- val : valtype
@@ -205,7 +227,7 @@ rule Extend_store:
 
 relation Frame_ok: store |- frame : context
 relation State_ok: |- state : context
-relation Config_ok: |- config : OK
+relation Config_ok: |- config : resulttype
 
 rule Frame_ok:
   s |- {LOCALS val*, MODULE moduleinst} : C ++ {LOCALS lct*}
@@ -218,6 +240,6 @@ rule State_ok:
   -- Frame_ok: s |- f : C
 
 rule Config_ok:
-  |- (s; f); instr* : OK
+  |- (s; f); instr* : t?
   -- State_ok: |- (s; f) : C
   -- Expr_ok2: s; C |- admininstr* : t?

--- a/specification/wasm-1.0/B-soundness.spectec
+++ b/specification/wasm-1.0/B-soundness.spectec
@@ -240,6 +240,6 @@ rule State_ok:
   -- Frame_ok: s |- f : C
 
 rule Config_ok:
-  |- (s; f); instr* : t?
-  -- State_ok: |- (s; f) : C
+  |- s; f; instr* : t?
+  -- State_ok: |- s; f : C
   -- Expr_ok2: s; C |- admininstr* : t?

--- a/specification/wasm-1.0/B-soundness.spectec
+++ b/specification/wasm-1.0/B-soundness.spectec
@@ -1,0 +1,222 @@
+;; Value type ok
+
+relation Val_ok: |- val : valtype
+
+rule Val_ok:
+  |- CONST t c_t : t
+
+
+;; Result type ok
+
+relation Result_ok: |- result : valtype*
+
+rule Result_ok/result:
+  |- _VALS v* : t*
+  -- (Val_ok: |- v : t)*
+
+rule Result_ok/trap:
+  |- TRAP : t*
+
+;; Administrative instructions
+
+syntax adminexpr = admininstr*
+
+relation Instr_ok2: store; context |- admininstr : functype
+  hint(prose "%3 is valid with %4")
+relation Instrs_ok2: store; context |- admininstr* : functype
+  hint(prose "%3 is valid with %4")
+relation Expr_ok2: store; context |- adminexpr : resulttype
+  hint(prose "%3 is valid with %4")
+
+rule Instr_ok2/plain:
+  s; C |- instr : t_1* -> t_2*
+  -- Instr_ok: C |- instr : t_1* -> t_2*
+
+rule Instr_ok2/label:
+  s; C |- LABEL_ n `{instr'*} admininstr* : eps -> t?
+  -- if |t'?| = n
+  -- Instrs_ok2: s; C |- instr'* : t'? -> t?
+  -- Instrs_ok2: s; {LABELS (t'?)} ++ C |- admininstr* : eps -> t?
+
+rule Instr_ok2/frame:
+  s; C |- FRAME_ n `{f} admininstr* : eps -> t?
+  -- if |t?| = n 
+  -- Frame_ok: s |- f : C'
+  -- Expr_ok2: s; C' |- admininstr* : t?
+
+rule Instr_ok2/call_addr:
+  s; C |- CALL_ADDR funcaddr : t_1* -> t_2*
+  -- Externaddr_ok: s |- FUNC funcaddr: FUNC (t_1* -> t_2*)
+
+rule Instr_ok2/trap:
+  s; C |- TRAP : t_1* -> t_2*
+
+
+rule Instrs_ok2/empty:
+  s; C |- eps : eps -> eps
+
+rule Instrs_ok2/seq:
+  s; C |- admininstr_1 admininstr_2* : t_1* -> t_3*
+  -- Instr_ok2: s; C |- admininstr_1 : t_1* -> t_2*
+  -- Instrs_ok2: s; C |- admininstr_2* : t_2* -> t_3*
+
+rule Instrs_ok2/frame:
+  s; C |- admininstr* : t* t_1* -> t* t_2*
+  -- Instrs_ok2: s; C |- admininstr* : t_1* -> t_2*
+
+rule Expr_ok2:
+  s; C |- admininstr* : t?
+  -- Instrs_ok2: s; C |- admininstr* : eps -> t?
+
+;; External addresses
+
+relation Externaddr_ok: store |- externaddr : externtype  hint(macro "%externaddr")
+
+rule Externaddr_ok/global:
+  s |- GLOBAL a : GLOBAL globalinst.TYPE
+  -- if s.GLOBALS[a] = globalinst
+
+rule Externaddr_ok/mem:
+  s |- MEM a : MEM meminst.TYPE
+  -- if s.MEMS[a] = meminst
+
+rule Externaddr_ok/table:
+  s |- TABLE a : TABLE tableinst.TYPE
+  -- if s.TABLES[a] = tableinst
+
+rule Externaddr_ok/func:
+  s |- FUNC a : FUNC funcinst.TYPE
+  -- if s.FUNCS[a] = funcinst
+
+rule Externaddr_ok/sub:
+  s |- externaddr : xt
+  -- Externaddr_ok: s |- externaddr : xt'
+  -- Externtype_sub: |- xt' <: xt
+
+;; Instances
+
+relation Globalinst_ok: store |- globalinst : globaltype
+relation Meminst_ok: store |- meminst : memtype
+relation Tableinst_ok: store |- tableinst : tabletype
+relation Funcinst_ok: store |- funcinst : functype
+relation Exportinst_ok: store |- exportinst : OK
+
+rule Globalinst_ok:
+  s |- {TYPE mut t, VALUE val} : mut t
+  -- Globaltype_ok: |- mut t : OK
+  -- Val_ok: |- val : t
+
+rule Meminst_ok:
+  s |- {TYPE `[n..m], BYTES b*} : `[n..m]
+  -- Memtype_ok: |- `[n..m] : OK
+  -- if |b*| = $(n * $($(64 * $Ki)))
+
+rule Tableinst_ok:
+  s |- {TYPE `[n..m] , REFS ref*} : `[n..m]
+  -- Tabletype_ok: |- `[n..m] : OK
+  -- if |ref*| = n
+
+rule Funcinst_ok:
+  s |- {TYPE ft, MODULE moduleinst, CODE func} : ft
+  -- Functype_ok: |- ft : OK
+  -- Moduleinst_ok: s |- moduleinst : C
+  -- Func_ok: C |- func : ft
+
+rule Exportinst_ok:
+  s |- {NAME nm, ADDR xa} : OK
+  -- Externaddr_ok: s |- xa : xt
+
+
+;; Modules
+
+relation Moduleinst_ok: store |- moduleinst : context
+
+rule Moduleinst_ok:
+  s |- { TYPES functype*,
+         GLOBALS globaladdr*,
+         MEMS memaddr*,
+         TABLES tableaddr*,
+         FUNCS funcaddr*,
+         EXPORTS exportinst* } :
+           { TYPES functype*,
+             GLOBALS globaltype*,
+             MEMS memtype*,
+             TABLES tabletype*,
+             FUNCS functype_F*,
+           }
+  -- (Functype_ok: |- functype : OK)*
+  -- (Externaddr_ok: s |- GLOBAL globaladdr : GLOBAL globaltype)*
+  -- (Externaddr_ok: s |- FUNC funcaddr : FUNC functype_F)*
+  -- (Externaddr_ok: s |- MEM memaddr : MEM memtype)*
+  -- (Externaddr_ok: s |- TABLE tableaddr : TABLE tabletype)*
+  -- (Exportinst_ok: s |- exportinst : OK)*
+  ----
+  -- if $disjoint_(name, (exportinst.NAME)*)
+  -- (if exportinst.ADDR <- (GLOBAL globaladdr)* (MEM memaddr)* (TABLE tableaddr)* (FUNC funcaddr)*)*
+
+
+;; Store
+
+relation Store_ok: |- store : OK
+
+rule Store_ok:
+  |- s : OK
+  -- (Globalinst_ok: s |- globalinst : globaltype)*
+  -- (Meminst_ok: s |- meminst : memtype)*
+  -- (Tableinst_ok: s |- tableinst : tabletype)*
+  -- (Funcinst_ok: s |- funcinst : functype)*
+  ----
+  -- if s = {GLOBALS globalinst*, MEMS meminst*, TABLES tableinst*, FUNCS funcinst*}
+
+;; Store extension
+
+relation Extend_globalinst: globalinst `<= globalinst
+relation Extend_meminst: meminst `<= meminst
+relation Extend_tableinst: tableinst `<= tableinst
+relation Extend_funcinst: funcinst `<= funcinst
+relation Extend_store: store `<= store
+
+rule Extend_globalinst:
+  {TYPE mut t, VALUE val} `<= {TYPE mut t, VALUE val'}
+  -- if mut = MUT \/ val = val'
+
+rule Extend_meminst:
+  {TYPE `[n..m], BYTES b*} `<= {TYPE `[n'..m], BYTES b'*}
+  -- if n <= n'
+  -- if |b*| <= |b'*|
+
+rule Extend_tableinst:
+  {TYPE `[n..m], REFS ref*} `<= {TYPE `[n'..m], REFS ref'*}
+  -- if n <= n'
+  -- if |ref*| <= |ref'*|
+
+rule Extend_funcinst:
+  {TYPE ft, MODULE mm, CODE fc} `<= {TYPE ft, MODULE mm, CODE fc}
+
+rule Extend_store:
+  s `<= s'
+  -- (Extend_globalinst: s.GLOBALS[a] `<= s'.GLOBALS[a] )^(a<|s.GLOBALS|)
+  -- (Extend_meminst: s.MEMS[a] `<= s'.MEMS[a] )^(a<|s.MEMS|)
+  -- (Extend_tableinst: s.TABLES[a] `<= s'.TABLES[a] )^(a<|s.TABLES|)
+  -- (Extend_funcinst: s.FUNCS[a] `<= s'.FUNCS[a] )^(a<|s.FUNCS|)
+
+;; Configurations
+
+relation Frame_ok: store |- frame : context
+relation State_ok: |- state : context
+relation Config_ok: |- config : OK
+
+rule Frame_ok:
+  s |- {LOCALS val*, MODULE moduleinst} : C ++ {LOCALS lct*}
+  -- Moduleinst_ok: s |- moduleinst : C
+  -- (Val_ok: |- val : t)*
+
+rule State_ok:
+  |- s; f : C
+  -- Store_ok: |- s : OK
+  -- Frame_ok: s |- f : C
+
+rule Config_ok:
+  |- (s; f); instr* : OK
+  -- State_ok: |- (s; f) : C
+  -- Expr_ok2: s; C |- admininstr* : t?

--- a/specification/wasm-2.0/0-aux.spectec
+++ b/specification/wasm-2.0/0-aux.spectec
@@ -56,3 +56,7 @@ def $setproduct1_(syntax X, eps, (w*)*) = eps
 def $setproduct1_(syntax X, w_1 w'*, (w*)*) = $setproduct2_(X, w_1, (w*)*) ++ $setproduct1_(X, w'*, (w*)*)
 def $setproduct2_(syntax X, w_1, eps) = eps
 def $setproduct2_(syntax X, w_1, (w'*) (w*)*) = (w_1 w'*) ++ $setproduct2_(X, w_1, (w*)*)
+
+def $disjoint_(syntax X, X*) : bool  hint(show %2 $disjoint) hint(macro none)
+def $disjoint_(syntax X, eps) = true
+def $disjoint_(syntax X, w w'*) = ~(w <- w'*) /\ $disjoint_(X, w'*)

--- a/specification/wasm-2.0/B-soundness.spectec
+++ b/specification/wasm-2.0/B-soundness.spectec
@@ -300,6 +300,6 @@ rule State_ok:
   -- Frame_ok: s |- f : C
 
 rule Config_ok:
-  |- (s; f); instr* : t*
-  -- State_ok: |- (s; f) : C
+  |- s; f; instr* : t*
+  -- State_ok: |- s; f : C
   -- Expr_ok2: s; C |- admininstr* : t*

--- a/specification/wasm-2.0/B-soundness.spectec
+++ b/specification/wasm-2.0/B-soundness.spectec
@@ -1,0 +1,281 @@
+;; Ref type ok
+
+relation Ref_ok: store |- ref : reftype
+
+rule Ref_ok/null:
+  s |- REF.NULL rt : rt
+
+rule Ref_ok/func:
+  s |- REF.FUNC_ADDR a : FUNCREF
+  -- Externaddr_ok: s |- FUNC a : FUNC ext
+
+rule Ref_ok/extern:
+  s |- REF.HOST_ADDR a : EXTERNREF
+
+;; Value type ok
+
+relation Val_ok: store |- val : valtype
+
+rule Val_ok/numtype:
+  s |- CONST nt c_t : nt
+
+rule Val_ok/vectype:
+  s |- VCONST vt c_t : vt
+
+rule Val_ok/reftype:
+  s |- r : rt
+  -- Ref_ok : s |- r : rt
+
+;; Result type ok
+
+relation Result_ok: store |- result : valtype*
+
+rule Result_ok/result:
+  s |- _VALS v* : t*
+  -- (Val_ok: s |- v : t)*
+
+rule Result_ok/trap:
+  s |- TRAP : t*
+
+;; Administrative instructions
+
+syntax adminexpr = admininstr*
+
+relation Instr_ok2: store; context |- admininstr : functype
+  hint(prose "%3 is valid with %4")
+relation Instrs_ok2: store; context |- admininstr* : functype
+  hint(prose "%3 is valid with %4")
+relation Expr_ok2: store; context |- adminexpr : resulttype
+  hint(prose "%3 is valid with %4")
+
+rule Instr_ok2/plain:
+  s; C |- instr : t_1* -> t_2*
+  -- Instr_ok: C |- instr : t_1* -> t_2*
+
+rule Instr_ok2/label:
+  s; C |- LABEL_ n `{instr'*} admininstr* : eps -> t*
+  -- Instrs_ok2: s; C |- instr'* : t'^n -> t*
+  -- Instrs_ok2: s; {LABELS (t')^n} ++ C |- admininstr* : eps -> t*
+
+rule Instr_ok2/frame:
+  s; C |- FRAME_ n `{f} admininstr* : eps -> t^n
+  -- Frame_ok: s |- f : C'
+  -- Expr_ok2: s; C' |- admininstr* : t^n
+
+rule Instr_ok2/call_addr:
+  s; C |- CALL_ADDR funcaddr : t_1* -> t_2*
+  -- Externaddr_ok: s |- FUNC funcaddr: FUNC (t_1* -> t_2*)
+
+rule Instr_ok2/ref:
+  s; C |- ref : eps -> rt
+  -- Ref_ok: s |- ref : rt
+
+rule Instr_ok2/trap:
+  s; C |- TRAP : t_1* -> t_2*
+
+
+rule Instrs_ok2/empty:
+  s; C |- eps : eps -> eps
+
+rule Instrs_ok2/seq:
+  s; C |- admininstr_1 admininstr_2* : t_1* -> t_3*
+  -- Instr_ok2: s; C |- admininstr_1 : t_1* -> t_2*
+  -- Instrs_ok2: s; C |- admininstr_2* : t_2* -> t_3*
+
+rule Instrs_ok2/sub:
+  s; C |- instr* : t'_1* -> t'_2*
+  -- Instrs_ok2: s; C |- admininstr* : t_1* -> t_2*
+  -- Resulttype_sub: |- t'_1* <: t_1*
+  -- Resulttype_sub: |- t_2* <: t'_2*
+
+rule Instrs_ok2/frame:
+  s; C |- admininstr* : t* t_1* -> t* t_2*
+  -- Instrs_ok2: s; C |- admininstr* : t_1* -> t_2*
+
+rule Expr_ok2:
+  s; C |- admininstr* : t*
+  -- Instrs_ok2: s; C |- admininstr* : eps -> t*
+
+;; External addresses
+
+relation Externaddr_ok: store |- externaddr : externtype  hint(macro "%externaddr")
+
+rule Externaddr_ok/global:
+  s |- GLOBAL a : GLOBAL globalinst.TYPE
+  -- if s.GLOBALS[a] = globalinst
+
+rule Externaddr_ok/mem:
+  s |- MEM a : MEM meminst.TYPE
+  -- if s.MEMS[a] = meminst
+
+rule Externaddr_ok/table:
+  s |- TABLE a : TABLE tableinst.TYPE
+  -- if s.TABLES[a] = tableinst
+
+rule Externaddr_ok/func:
+  s |- FUNC a : FUNC funcinst.TYPE
+  -- if s.FUNCS[a] = funcinst
+
+rule Externaddr_ok/sub:
+  s |- externaddr : xt
+  -- Externaddr_ok: s |- externaddr : xt'
+  -- Externtype_sub: |- xt' <: xt
+
+;; Instances
+
+relation Globalinst_ok: store |- globalinst : globaltype
+relation Meminst_ok: store |- meminst : memtype
+relation Tableinst_ok: store |- tableinst : tabletype
+relation Funcinst_ok: store |- funcinst : functype
+relation Datainst_ok: store |- datainst : datatype
+relation Eleminst_ok: store |- eleminst : elemtype
+relation Exportinst_ok: store |- exportinst : OK
+
+rule Globalinst_ok:
+  s |- {TYPE mut t, VALUE val} : mut t
+  -- Globaltype_ok: |- mut t : OK
+  -- Val_ok: s |- val : t
+
+rule Meminst_ok:
+  s |- {TYPE `[n..m] PAGE, BYTES b*} : `[n..m] PAGE
+  -- Memtype_ok: |- `[n..m] PAGE : OK
+  -- if |b*| = $(n * $($(64 * $Ki)))
+
+rule Tableinst_ok:
+  s |- {TYPE `[n..m] rt , REFS ref*} : `[n..m] rt
+  -- Tabletype_ok: |- `[n..m] rt : OK
+  -- (Ref_ok : s |- ref : rt)*
+  -- if |ref*| = n
+
+rule Funcinst_ok:
+  s |- {TYPE ft, MODULE moduleinst, CODE func} : ft
+  -- Functype_ok: |- ft : OK
+  -- Moduleinst_ok: s |- moduleinst : C
+  -- Func_ok: C |- func : ft
+
+rule Datainst_ok:
+  s |- {BYTES b*} : OK
+
+rule Eleminst_ok:
+  s |- {TYPE rt, REFS ref*} : rt
+  -- (Ref_ok: s |- ref : rt)*
+
+rule Exportinst_ok:
+  s |- {NAME nm, ADDR xa} : OK
+  -- Externaddr_ok: s |- xa : xt
+
+
+;; Modules
+
+relation Moduleinst_ok: store |- moduleinst : context
+
+rule Moduleinst_ok:
+  s |- { TYPES functype*,
+         GLOBALS globaladdr*,
+         MEMS memaddr*,
+         TABLES tableaddr*,
+         FUNCS funcaddr*,
+         DATAS dataaddr*,
+         ELEMS elemaddr*,
+         EXPORTS exportinst* } :
+           { TYPES functype*,
+             GLOBALS globaltype*,
+             MEMS memtype*,
+             TABLES tabletype*,
+             FUNCS functype_F*,
+             DATAS datatype*,
+             ELEMS elemtype*,
+           }
+  -- (Functype_ok: |- functype : OK)*
+  -- (Externaddr_ok: s |- GLOBAL globaladdr : GLOBAL globaltype)*
+  -- (Externaddr_ok: s |- FUNC funcaddr : FUNC functype_F)*
+  -- (Externaddr_ok: s |- MEM memaddr : MEM memtype)*
+  -- (Externaddr_ok: s |- TABLE tableaddr : TABLE tabletype)*
+  -- (Exportinst_ok: s |- exportinst : OK)*
+  ----
+  -- (Datainst_ok: s |- s.DATAS[dataaddr] : datatype)*
+  -- (Eleminst_ok: s |- s.ELEMS[elemaddr] : elemtype)*
+  ----
+  -- if $disjoint_(name, (exportinst.NAME)*)
+  -- (if exportinst.ADDR <- (GLOBAL globaladdr)* (MEM memaddr)* (TABLE tableaddr)* (FUNC funcaddr)*)*
+
+;; Store
+
+relation Store_ok: |- store : OK
+
+rule Store_ok:
+  |- s : OK
+  -- (Globalinst_ok: s |- globalinst : globaltype)*
+  -- (Meminst_ok: s |- meminst : memtype)*
+  -- (Tableinst_ok: s |- tableinst : tabletype)*
+  -- (Funcinst_ok: s |- funcinst : functype)*
+  -- (Datainst_ok: s |- datainst : datatype)*
+  -- (Eleminst_ok: s |- eleminst : elemtype)*
+  ----
+  -- if s = {GLOBALS globalinst*, MEMS meminst*, TABLES tableinst*, 
+             FUNCS funcinst*, DATAS datainst*, ELEMS eleminst*}
+
+;; Store extension
+
+relation Extend_globalinst: globalinst `<= globalinst
+relation Extend_meminst: meminst `<= meminst
+relation Extend_tableinst: tableinst `<= tableinst
+relation Extend_funcinst: funcinst `<= funcinst
+relation Extend_datainst: datainst `<= datainst
+relation Extend_eleminst: eleminst `<= eleminst
+relation Extend_store: store `<= store
+
+rule Extend_globalinst:
+  {TYPE mut t, VALUE val} `<= {TYPE mut t, VALUE val'}
+  -- if mut = MUT \/ val = val'
+
+rule Extend_meminst:
+  {TYPE `[n..m] PAGE, BYTES b*} `<= {TYPE `[n'..m] PAGE, BYTES b'*}
+  -- if n <= n'
+  -- if |b*| <= |b'*|
+
+rule Extend_tableinst:
+  {TYPE `[n..m] rt, REFS ref*} `<= {TYPE `[n'..m] rt, REFS ref'*}
+  -- if n <= n'
+  -- if |ref*| <= |ref'*|
+
+rule Extend_funcinst:
+  {TYPE ft, MODULE mm, CODE fc} `<= {TYPE ft, MODULE mm, CODE fc}
+
+rule Extend_datainst:
+  {BYTES b*} `<= {BYTES b'*}
+  -- if b* = b'* \/ b'* = eps
+
+rule Extend_eleminst:
+  {TYPE rt, REFS ref*} `<= {TYPE rt, REFS ref'*}
+  -- if ref* = ref'* \/ ref'* = eps
+
+rule Extend_store:
+  s `<= s'
+  -- (Extend_globalinst: s.GLOBALS[a] `<= s'.GLOBALS[a] )^(a<|s.GLOBALS|)
+  -- (Extend_meminst: s.MEMS[a] `<= s'.MEMS[a] )^(a<|s.MEMS|)
+  -- (Extend_tableinst: s.TABLES[a] `<= s'.TABLES[a] )^(a<|s.TABLES|)
+  -- (Extend_funcinst: s.FUNCS[a] `<= s'.FUNCS[a] )^(a<|s.FUNCS|)
+  -- (Extend_datainst: s.DATAS[a] `<= s'.DATAS[a] )^(a<|s.DATAS|)
+  -- (Extend_eleminst: s.ELEMS[a] `<= s'.ELEMS[a] )^(a<|s.ELEMS|)
+
+;; Configurations
+
+relation Frame_ok: store |- frame : context
+relation State_ok: |- state : context
+relation Config_ok: |- config : OK
+
+rule Frame_ok:
+  s |- {LOCALS val*, MODULE moduleinst} : C ++ {LOCALS lct*}
+  -- Moduleinst_ok: s |- moduleinst : C
+  -- (Val_ok: s |- val : t)*
+
+rule State_ok:
+  |- s; f : C
+  -- Store_ok: |- s : OK
+  -- Frame_ok: s |- f : C
+
+rule Config_ok:
+  |- (s; f); instr* : OK
+  -- State_ok: |- (s; f) : C
+  -- Expr_ok2: s; C |- admininstr* : t*

--- a/specification/wasm-2.0/B-soundness.spectec
+++ b/specification/wasm-2.0/B-soundness.spectec
@@ -1,3 +1,27 @@
+;; Contexts
+
+relation Context_ok: |- context : OK  hint(macro "%context")
+
+rule Context_ok:
+  |- C : OK
+  -- if C =
+    { TYPES ft*,
+      FUNCS ft_2*,
+      GLOBALS gt*,
+      MEMS mt*,
+      TABLES tt*,
+      LOCALS lct*,
+      DATAS ok*,
+      ELEMS et*,
+      LABELS rt*,
+      RETURN rt'?,
+    }
+  -- (Functype_ok: |- ft : OK)*
+  -- (Globaltype_ok: |- gt : OK)*
+  -- (Memtype_ok: |- mt : OK)*
+  -- (Tabletype_ok: |- tt : OK)*
+  -- (Functype_ok: |- ft_2 : OK)*
+
 ;; Ref type ok
 
 relation Ref_ok: store |- ref : reftype
@@ -263,7 +287,7 @@ rule Extend_store:
 
 relation Frame_ok: store |- frame : context
 relation State_ok: |- state : context
-relation Config_ok: |- config : OK
+relation Config_ok: |- config : resulttype
 
 rule Frame_ok:
   s |- {LOCALS val*, MODULE moduleinst} : C ++ {LOCALS lct*}
@@ -276,6 +300,6 @@ rule State_ok:
   -- Frame_ok: s |- f : C
 
 rule Config_ok:
-  |- (s; f); instr* : OK
+  |- (s; f); instr* : t*
   -- State_ok: |- (s; f) : C
   -- Expr_ok2: s; C |- admininstr* : t*

--- a/specification/wasm-2.0/B-soundness.spectec
+++ b/specification/wasm-2.0/B-soundness.spectec
@@ -290,7 +290,7 @@ relation State_ok: |- state : context
 relation Config_ok: |- config : resulttype
 
 rule Frame_ok:
-  s |- {LOCALS val*, MODULE moduleinst} : C ++ {LOCALS lct*}
+  s |- {LOCALS val*, MODULE moduleinst} : C ++ {LOCALS t*}
   -- Moduleinst_ok: s |- moduleinst : C
   -- (Val_ok: s |- val : t)*
 

--- a/specification/wasm-3.0/7.1-soundness.configurations.spectec
+++ b/specification/wasm-3.0/7.1-soundness.configurations.spectec
@@ -319,7 +319,7 @@ rule Extend_store:
 relation Localval_ok: store |- val? : localtype
 relation Frame_ok: store |- frame : context
 relation State_ok: |- state : context
-relation Config_ok: |- config : OK
+relation Config_ok: |- config : resulttype
 
 rule Localval_ok/set:
   s |- val : SET t
@@ -339,6 +339,6 @@ rule State_ok:
   -- Frame_ok: s |- f : C
 
 rule Config_ok:
-  |- z; instr* : OK
-  -- State_ok: |- z : C
-  -- Expr_ok: C |- instr* : t*
+  |- (s; f); instr* : t*
+  -- State_ok: |- (s; f) : C
+  -- Expr_ok2: s; C |- instr* : t*

--- a/specification/wasm-3.0/7.1-soundness.configurations.spectec
+++ b/specification/wasm-3.0/7.1-soundness.configurations.spectec
@@ -339,6 +339,6 @@ rule State_ok:
   -- Frame_ok: s |- f : C
 
 rule Config_ok:
-  |- (s; f); instr* : t*
-  -- State_ok: |- (s; f) : C
+  |- s; f; instr* : t*
+  -- State_ok: |- s; f : C
   -- Expr_ok2: s; C |- instr* : t*


### PR DESCRIPTION
This pull request is to take the soundness spec in 3.0 and modify it so that it works for Wasm 1.0 and 2.0.

Currently a draft so that I can ask some questions about it before merging