### PR TITLE
[Spec] Soundness spec typos

### DIFF
--- a/specification/wasm-1.0/B-soundness.spectec
+++ b/specification/wasm-1.0/B-soundness.spectec
@@ -240,6 +240,6 @@ rule State_ok:
   -- Frame_ok: s |- f : C
 
 rule Config_ok:
-  |- s; f; instr* : t?
+  |- s; f; admininstr* : t?
   -- State_ok: |- s; f : C
   -- Expr_ok2: s; C |- admininstr* : t?

--- a/specification/wasm-1.0/B-soundness.spectec
+++ b/specification/wasm-1.0/B-soundness.spectec
@@ -204,12 +204,12 @@ rule Extend_globalinst:
   -- if mut = MUT \/ val = val'
 
 rule Extend_meminst:
-  {TYPE `[n..m], BYTES b*} `<= {TYPE `[n'..m], BYTES b'*}
+  {TYPE `[n..m?], BYTES b*} `<= {TYPE `[n'..m?], BYTES b'*}
   -- if n <= n'
   -- if |b*| <= |b'*|
 
 rule Extend_tableinst:
-  {TYPE `[n..m], REFS ref*} `<= {TYPE `[n'..m], REFS ref'*}
+  {TYPE `[n..m?], REFS ref*} `<= {TYPE `[n'..m?], REFS ref'*}
   -- if n <= n'
   -- if |ref*| <= |ref'*|
 

--- a/specification/wasm-1.0/B-soundness.spectec
+++ b/specification/wasm-1.0/B-soundness.spectec
@@ -129,13 +129,13 @@ rule Globalinst_ok:
   -- Val_ok: |- val : t
 
 rule Meminst_ok:
-  s |- {TYPE `[n..m], BYTES b*} : `[n..m]
-  -- Memtype_ok: |- `[n..m] : OK
+  s |- {TYPE `[n..m?], BYTES b*} : `[n..m?]
+  -- Memtype_ok: |- `[n..m?] : OK
   -- if |b*| = $(n * $($(64 * $Ki)))
 
 rule Tableinst_ok:
-  s |- {TYPE `[n..m] , REFS (fa?)*} : `[n..m]
-  -- Tabletype_ok: |- `[n..m] : OK
+  s |- {TYPE `[n..m?] , REFS (fa?)*} : `[n..m?]
+  -- Tabletype_ok: |- `[n..m?] : OK
   -- ((Externaddr_ok: s |- FUNC fa : FUNC ft)?)*
   -- if |(fa?)*| = n
 

--- a/specification/wasm-2.0/B-soundness.spectec
+++ b/specification/wasm-2.0/B-soundness.spectec
@@ -300,6 +300,6 @@ rule State_ok:
   -- Frame_ok: s |- f : C
 
 rule Config_ok:
-  |- s; f; instr* : t*
+  |- s; f; admininstr* : t*
   -- State_ok: |- s; f : C
   -- Expr_ok2: s; C |- admininstr* : t*

--- a/specification/wasm-2.0/B-soundness.spectec
+++ b/specification/wasm-2.0/B-soundness.spectec
@@ -254,12 +254,12 @@ rule Extend_globalinst:
   -- if mut = MUT \/ val = val'
 
 rule Extend_meminst:
-  {TYPE `[n..m] PAGE, BYTES b*} `<= {TYPE `[n'..m] PAGE, BYTES b'*}
+  {TYPE `[n..m?] PAGE, BYTES b*} `<= {TYPE `[n'..m?] PAGE, BYTES b'*}
   -- if n <= n'
   -- if |b*| <= |b'*|
 
 rule Extend_tableinst:
-  {TYPE `[n..m] rt, REFS ref*} `<= {TYPE `[n'..m] rt, REFS ref'*}
+  {TYPE `[n..m?] rt, REFS ref*} `<= {TYPE `[n'..m?] rt, REFS ref'*}
   -- if n <= n'
   -- if |ref*| <= |ref'*|
 

--- a/specification/wasm-2.0/B-soundness.spectec
+++ b/specification/wasm-2.0/B-soundness.spectec
@@ -107,7 +107,7 @@ rule Instrs_ok2/seq:
   -- Instrs_ok2: s; C |- admininstr_2* : t_2* -> t_3*
 
 rule Instrs_ok2/sub:
-  s; C |- instr* : t'_1* -> t'_2*
+  s; C |- admininstr* : t'_1* -> t'_2*
   -- Instrs_ok2: s; C |- admininstr* : t_1* -> t_2*
   -- Resulttype_sub: |- t'_1* <: t_1*
   -- Resulttype_sub: |- t_2* <: t'_2*

--- a/specification/wasm-2.0/B-soundness.spectec
+++ b/specification/wasm-2.0/B-soundness.spectec
@@ -161,13 +161,13 @@ rule Globalinst_ok:
   -- Val_ok: s |- val : t
 
 rule Meminst_ok:
-  s |- {TYPE `[n..m] PAGE, BYTES b*} : `[n..m] PAGE
-  -- Memtype_ok: |- `[n..m] PAGE : OK
+  s |- {TYPE `[n..m?] PAGE, BYTES b*} : `[n..m?] PAGE
+  -- Memtype_ok: |- `[n..m?] PAGE : OK
   -- if |b*| = $(n * $($(64 * $Ki)))
 
 rule Tableinst_ok:
-  s |- {TYPE `[n..m] rt , REFS ref*} : `[n..m] rt
-  -- Tabletype_ok: |- `[n..m] rt : OK
+  s |- {TYPE `[n..m?] rt , REFS ref*} : `[n..m?] rt
+  -- Tabletype_ok: |- `[n..m?] rt : OK
   -- (Ref_ok : s |- ref : rt)*
   -- if |ref*| = n
 

--- a/specification/wasm-3.0/7.1-soundness.configurations.spectec
+++ b/specification/wasm-3.0/7.1-soundness.configurations.spectec
@@ -86,13 +86,13 @@ rule Globalinst_ok:
   -- Val_ok: s |- val : t
 
 rule Meminst_ok:
-  s |- {TYPE at `[n..m] PAGE, BYTES b*} : at `[n..m] PAGE
-  -- Memtype_ok: {} |- at `[n..m] PAGE : OK
+  s |- {TYPE at `[n..m?] PAGE, BYTES b*} : at `[n..m?] PAGE
+  -- Memtype_ok: {} |- at `[n..m?] PAGE : OK
   -- if |b*| = $(n * $($(64 * $Ki)))
 
 rule Tableinst_ok:
-  s |- {TYPE at `[n..m] rt, REFS ref*} : at `[n..m] rt
-  -- Tabletype_ok: {} |- at `[n..m] rt : OK
+  s |- {TYPE at `[n..m?] rt, REFS ref*} : at `[n..m?] rt
+  -- Tabletype_ok: {} |- at `[n..m?] rt : OK
   -- if |ref*| = n
   -- (Ref_ok: s |- ref : rt)*
 

--- a/specification/wasm-3.0/7.1-soundness.configurations.spectec
+++ b/specification/wasm-3.0/7.1-soundness.configurations.spectec
@@ -262,12 +262,12 @@ rule Extend_globalinst:
   -- if mut? = MUT \/ val = val'
 
 rule Extend_meminst:
-  {TYPE at `[n..m] PAGE, BYTES b*} `<= {TYPE at `[n'..m] PAGE, BYTES b'*}
+  {TYPE at `[n..m?] PAGE, BYTES b*} `<= {TYPE at `[n'..m?] PAGE, BYTES b'*}
   -- if n <= n'
   -- if |b*| <= |b'*|
 
 rule Extend_tableinst:
-  {TYPE at `[n..m] rt, REFS ref*} `<= {TYPE at `[n'..m] rt, REFS ref'*}
+  {TYPE at `[n..m?] rt, REFS ref*} `<= {TYPE at `[n'..m?] rt, REFS ref'*}
   -- if n <= n'
   -- if |ref*| <= |ref'*|
 

--- a/specification/wasm-latest/7.1-soundness.configurations.spectec
+++ b/specification/wasm-latest/7.1-soundness.configurations.spectec
@@ -86,13 +86,13 @@ rule Globalinst_ok:
   -- Val_ok: s |- val : t
 
 rule Meminst_ok:
-  s |- {TYPE at `[n..m] PAGE, BYTES b*} : at `[n..m] PAGE
-  -- Memtype_ok: {} |- at `[n..m] PAGE : OK
+  s |- {TYPE at `[n..m?] PAGE, BYTES b*} : at `[n..m?] PAGE
+  -- Memtype_ok: {} |- at `[n..m?] PAGE : OK
   -- if |b*| = $(n * $($(64 * $Ki)))
 
 rule Tableinst_ok:
-  s |- {TYPE at `[n..m] rt, REFS ref*} : at `[n..m] rt
-  -- Tabletype_ok: {} |- at `[n..m] rt : OK
+  s |- {TYPE at `[n..m?] rt, REFS ref*} : at `[n..m?] rt
+  -- Tabletype_ok: {} |- at `[n..m?] rt : OK
   -- if |ref*| = n
   -- (Ref_ok: s |- ref : rt)*
 

--- a/specification/wasm-latest/7.1-soundness.configurations.spectec
+++ b/specification/wasm-latest/7.1-soundness.configurations.spectec
@@ -86,12 +86,12 @@ rule Globalinst_ok:
   -- Val_ok: s |- val : t
 
 rule Meminst_ok:
-  s |- {TYPE at `[n..m?] PAGE, BYTES b*} : at `[n..m] PAGE
+  s |- {TYPE at `[n..m] PAGE, BYTES b*} : at `[n..m] PAGE
   -- Memtype_ok: {} |- at `[n..m] PAGE : OK
   -- if |b*| = $(n * $($(64 * $Ki)))
 
 rule Tableinst_ok:
-  s |- {TYPE at `[n..m?] rt, REFS ref*} : at `[n..m] rt
+  s |- {TYPE at `[n..m] rt, REFS ref*} : at `[n..m] rt
   -- Tabletype_ok: {} |- at `[n..m] rt : OK
   -- if |ref*| = n
   -- (Ref_ok: s |- ref : rt)*
@@ -262,12 +262,12 @@ rule Extend_globalinst:
   -- if mut? = MUT \/ val = val'
 
 rule Extend_meminst:
-  {TYPE at `[n..m] PAGE, BYTES b*} `<= {TYPE at `[n'..m] PAGE, BYTES b'*}
+  {TYPE at `[n..m?] PAGE, BYTES b*} `<= {TYPE at `[n'..m?] PAGE, BYTES b'*}
   -- if n <= n'
   -- if |b*| <= |b'*|
 
 rule Extend_tableinst:
-  {TYPE at `[n..m] rt, REFS ref*} `<= {TYPE at `[n'..m] rt, REFS ref'*}
+  {TYPE at `[n..m?] rt, REFS ref*} `<= {TYPE at `[n'..m?] rt, REFS ref'*}
   -- if n <= n'
   -- if |ref*| <= |ref'*|
 

--- a/specification/wasm-latest/7.1-soundness.configurations.spectec
+++ b/specification/wasm-latest/7.1-soundness.configurations.spectec
@@ -86,12 +86,12 @@ rule Globalinst_ok:
   -- Val_ok: s |- val : t
 
 rule Meminst_ok:
-  s |- {TYPE at `[n..m] PAGE, BYTES b*} : at `[n..m] PAGE
+  s |- {TYPE at `[n..m?] PAGE, BYTES b*} : at `[n..m] PAGE
   -- Memtype_ok: {} |- at `[n..m] PAGE : OK
   -- if |b*| = $(n * $($(64 * $Ki)))
 
 rule Tableinst_ok:
-  s |- {TYPE at `[n..m] rt, REFS ref*} : at `[n..m] rt
+  s |- {TYPE at `[n..m?] rt, REFS ref*} : at `[n..m] rt
   -- Tabletype_ok: {} |- at `[n..m] rt : OK
   -- if |ref*| = n
   -- (Ref_ok: s |- ref : rt)*


### PR DESCRIPTION
Some typos in the soundness spec that must be resolved for mechanization backends. @rossberg does the store extension change make sense? Previously the store extension relations only allowed memories/tables with a defined max.